### PR TITLE
Mordred: enumerate the connected subgraphs once, with array operations

### DIFF
--- a/skfp/fingerprints/_new_mordred/calculator.py
+++ b/skfp/fingerprints/_new_mordred/calculator.py
@@ -55,6 +55,7 @@ from skfp.fingerprints._new_mordred.utils.graph_matrix import (
     DistanceMatrix3D,
 )
 from skfp.fingerprints._new_mordred.utils.mol_preprocess import preprocess_mol
+from skfp.fingerprints._new_mordred.utils.subgraphs import Subgraphs
 
 """
 This code has been adapted from the BSD-licensed mordred-community library.
@@ -173,6 +174,7 @@ def compute(mol: Mol, use_3D: bool) -> np.ndarray:
     # per-atom property arrays and rings, read from the molecule once and shared
     props_regular = AtomicProperties.from_mol(mol_regular)
     rings_regular = ring_count.RingSets(mol_regular, props_regular)
+    subgraphs_regular = Subgraphs(props_regular)
 
     # hydrogen-explicit molecule
     # added hydrogens have no coordinates, so for 3D we build this separately
@@ -204,7 +206,7 @@ def compute(mol: Mol, use_3D: bool) -> np.ndarray:
     descriptors_2d: dict[ModuleType, np.ndarray] = {
         abc_index: abc_index.calc(mol_regular, distance_matrix_regular),
         walk_count: walk_count.calc(mol_regular, adjacency_matrix_regular),
-        path_count: path_count.calc(mol_regular),
+        path_count: path_count.calc(props_regular, subgraphs_regular),
         adjacency_matrix: adjacency_matrix.calc(
             props_regular,
             n_frags,
@@ -248,7 +250,7 @@ def compute(mol: Mol, use_3D: bool) -> np.ndarray:
         ),
         cpsa: cpsa_2d,
         polarizability: polarizability.calc(props_hydrogens),
-        chi: chi.calc(mol_regular),
+        chi: chi.calc(props_regular, subgraphs_regular),
         fragment_complexity: fragment_complexity.calc(props_regular),
         eccentric_connectivity_index: eccentric_connectivity_index.calc(
             adjacency_matrix_regular, distance_matrix_regular

--- a/skfp/fingerprints/_new_mordred/descriptors/carbon_types.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/carbon_types.py
@@ -1,8 +1,3 @@
-from collections import defaultdict
-
-import numpy as np
-from rdkit.Chem import HybridizationType, Mol
-
 """
 Carbon type descriptors.
 
@@ -11,6 +6,11 @@ https://github.com/JacksonBurns/mordred-community
 
 See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
 """
+
+from collections import defaultdict
+
+import numpy as np
+from rdkit.Chem import HybridizationType, Mol
 
 FEATURE_NAMES = [
     "C1SP1",

--- a/skfp/fingerprints/_new_mordred/descriptors/carbon_types.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/carbon_types.py
@@ -1,16 +1,14 @@
-"""
-Carbon type descriptors.
+from collections import defaultdict
 
+import numpy as np
+from rdkit.Chem import HybridizationType, Mol
+
+"""
 This code has been adapted from the BSD-licensed mordred-community library.
 https://github.com/JacksonBurns/mordred-community
 
 See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
 """
-
-from collections import defaultdict
-
-import numpy as np
-from rdkit.Chem import HybridizationType, Mol
 
 FEATURE_NAMES = [
     "C1SP1",

--- a/skfp/fingerprints/_new_mordred/descriptors/chi.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/chi.py
@@ -1,12 +1,9 @@
-from collections import defaultdict
-
 import numpy as np
-from rdkit import Chem
-from rdkit.Chem import Mol
 
-from skfp.fingerprints._new_mordred.utils.atomic_properties import (
-    get_sigma_electrons,
-    get_valence_electrons,
+from skfp.fingerprints._new_mordred.utils.atomic_properties import AtomicProperties
+from skfp.fingerprints._new_mordred.utils.subgraphs import (
+    Subgraphs,
+    SubgraphsTopology,
 )
 
 """
@@ -16,162 +13,124 @@ https://github.com/JacksonBurns/mordred-community
 See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
 """
 
+# subgraph classes
+CHAIN = "chain"  # closes a cycle, branched or not
+PATH = "path"  # acyclic, and no atom joins more than two of its bonds
+PATH_CLUSTER = "path_cluster"  # acyclic and branched, some atom joining exactly two
+CLUSTER = "cluster"  # acyclic and branched, no atom joining exactly two
+SUBGRAPH_TYPES = (CHAIN, PATH, PATH_CLUSTER, CLUSTER)
+
+# The chi families: each covers one subgraph class over a range of orders, and is
+# named by the prefix its features carry. An "A" prefix averages over the subgraphs
+# instead of only summing, so Xp and AXp read the same sums.
+_FAMILIES = (
+    (CHAIN, range(3, 8), ("Xch",)),
+    (CLUSTER, range(3, 7), ("Xc",)),
+    (PATH_CLUSTER, range(4, 7), ("Xpc",)),
+    (PATH, range(8), ("Xp", "AXp")),
+)
+
+# the atom weightings the chi indices use, in the order calc() stacks them:
+# "d" weights an atom by its sigma electrons, "dv" by its valence electrons
+_PROPS = ("d", "dv")
+
+
 FEATURE_NAMES = [
-    "Xch-3d",
-    "Xch-4d",
-    "Xch-5d",
-    "Xch-6d",
-    "Xch-7d",
-    "Xch-3dv",
-    "Xch-4dv",
-    "Xch-5dv",
-    "Xch-6dv",
-    "Xch-7dv",
-    "Xc-3d",
-    "Xc-4d",
-    "Xc-5d",
-    "Xc-6d",
-    "Xc-3dv",
-    "Xc-4dv",
-    "Xc-5dv",
-    "Xc-6dv",
-    "Xpc-4d",
-    "Xpc-5d",
-    "Xpc-6d",
-    "Xpc-4dv",
-    "Xpc-5dv",
-    "Xpc-6dv",
-    "Xp-0d",
-    "Xp-1d",
-    "Xp-2d",
-    "Xp-3d",
-    "Xp-4d",
-    "Xp-5d",
-    "Xp-6d",
-    "Xp-7d",
-    "AXp-0d",
-    "AXp-1d",
-    "AXp-2d",
-    "AXp-3d",
-    "AXp-4d",
-    "AXp-5d",
-    "AXp-6d",
-    "AXp-7d",
-    "Xp-0dv",
-    "Xp-1dv",
-    "Xp-2dv",
-    "Xp-3dv",
-    "Xp-4dv",
-    "Xp-5dv",
-    "Xp-6dv",
-    "Xp-7dv",
-    "AXp-0dv",
-    "AXp-1dv",
-    "AXp-2dv",
-    "AXp-3dv",
-    "AXp-4dv",
-    "AXp-5dv",
-    "AXp-6dv",
-    "AXp-7dv",
+    f"{prefix}-{order}{prop}"
+    for _, orders, prefixes in _FAMILIES
+    for order in orders
+    for prefix in prefixes
+    for prop in _PROPS
 ]
-_CHI_TYPES = ("chain", "path", "path_cluster", "cluster")
-_CHI_PREFIX_TO_TYPE = {
-    "Xch": "chain",
-    "Xp": "path",
-    "AXp": "path",
-    "Xpc": "path_cluster",
-    "Xc": "cluster",
-}
 
 
-def calc(mol: Mol) -> np.ndarray:
+def calc(props: AtomicProperties, subgraphs: Subgraphs) -> np.ndarray:
     """
-    Compute Mordred Chi descriptors without adding explicit hydrogens.
+    Chi descriptors, shape ``(n_features,)``.
+
+    Each descriptor sums ``prod(property over the subgraph atoms) ** -0.5`` over the
+    subgraphs of one order and class. Both properties are summed in the same pass
+    over each set of subgraphs, since the two differ only in what they weigh the
+    same atoms by, and the averaged families reuse the sums of their plain ones.
     """
-    properties = {
-        "d": np.asarray(
-            [get_sigma_electrons(atom) for atom in mol.GetAtoms()],
-            dtype=np.float32,
-        ),
-        "dv": np.asarray(
-            [get_valence_electrons(atom) for atom in mol.GetAtoms()],
-            dtype=np.float32,
-        ),
-    }
-    subgraphs_by_order = {order: _chi_subgraphs(mol, order) for order in range(1, 8)}
+    # one row per weighting, in _PROPS order, so that a row of the sums below lines
+    # up with the feature name that reads it
+    prop_vals = np.stack([props.sigma_electrons.astype(float), props.valence_electrons])
 
     values = []
-    for name in FEATURE_NAMES:
-        chi_type, order, prop, averaged = _parse_chi_feature_name(name)
-        if order == 0:
-            node_sets = [[atom.GetIdx()] for atom in mol.GetAtoms()]
-        else:
-            node_sets = subgraphs_by_order[order][chi_type]
-        values.append(_chi_value(node_sets, properties[prop], averaged))
+    for subgraph_type, orders, prefixes in _FAMILIES:
+        for order in orders:
+            products = _subgraph_prop_products(
+                subgraphs, order, subgraph_type, prop_vals
+            )
+            totals, num_subgraphs = _chi_sums(products)
+
+            for prefix in prefixes:
+                averaged = prefix.startswith("A")
+                for total in totals:
+                    if averaged:
+                        total = total / num_subgraphs if num_subgraphs else np.nan
+                    values.append(total)
 
     return np.asarray(values, dtype=np.float32)
 
 
-def _chi_subgraphs(mol: Mol, order: int) -> dict[str, list[list[int]]]:
-    classified: dict[str, list[list[int]]] = {chi_type: [] for chi_type in _CHI_TYPES}
-    bond_endpoints = [
-        (bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()) for bond in mol.GetBonds()
-    ]
+def _subgraph_prop_products(
+    subgraphs: Subgraphs,
+    order: int,
+    subgraph_type: str,
+    prop_vals: np.ndarray,
+) -> np.ndarray:
+    """
+    Product of every property over the atoms of each subgraph of one order and chi
+    class, shape ``(n_props, n_subgraphs)``.
 
-    for bond_idxs in Chem.FindAllSubgraphsOfLengthN(mol, order):
-        # count how many subgraph edges are incident to each atom (its degree
-        # within this subgraph)
-        deg: defaultdict[int, int] = defaultdict(int)
-        for a, b in (bond_endpoints[i] for i in bond_idxs):
-            deg[a] += 1
-            deg[b] += 1
+    Order 0 and the paths are read off directly. Other classes need this
+    order's subgraphs classified.
+    """
+    if order == 0:
+        # order 0 subgraphs are the individual atoms, which belong to every class,
+        # so each product is over a single atom
+        return prop_vals
 
-        # A subgraph contains a cycle iff n_edges >= n_nodes (for connected subgraphs).
-        if len(bond_idxs) >= len(deg):
-            chi_type = "chain"
-        else:
-            d = set(deg.values())
-            if d <= {1, 2}:
-                chi_type = "path"
-            elif 2 in d:
-                chi_type = "path_cluster"
-            else:
-                chi_type = "cluster"
+    if subgraph_type == PATH:
+        # the paths are already held as atoms, for the path count descriptors
+        return prop_vals[:, subgraphs.paths(order).atom_idxs].prod(axis=2)
 
-        classified[chi_type].append(list(deg.keys()))
-
-    return classified
+    topology = subgraphs.topology(order)
+    class_mask = _class_mask(topology, subgraph_type)
+    return topology.atom_products(prop_vals)[:, class_mask]
 
 
-def _parse_chi_feature_name(name: str) -> tuple[str, int, str, bool]:
-    prefix, order_and_prop = name.split("-", maxsplit=1)
-    averaged = prefix.startswith("A")
-    chi_type = _CHI_PREFIX_TO_TYPE[prefix]
-    order = int(order_and_prop[0])
-    prop = order_and_prop[1:]
-    return chi_type, order, prop, averaged
+def _class_mask(topology: SubgraphsTopology, subgraph_type: str) -> np.ndarray:
+    """
+    Which subgraphs of a given order belong to a given subgraph type (Chi class).
+    Which of one order's subgraphs belong to a chi class, shape ``(n_subgraphs,)``.
+
+    The four classes partition the subgraphs, so exactly one of these masks holds
+    for any given subgraph.
+
+    Returns a mask over subgraphs, array of shape (n_subgraphs,).
+    """
+    if subgraph_type == CHAIN:
+        return topology.is_cyclic
+    if subgraph_type == PATH:
+        return topology.is_path
+
+    is_branched = ~topology.is_cyclic & (topology.max_degree > 2)
+    if subgraph_type == PATH_CLUSTER:
+        return is_branched & topology.has_degree_2
+    if subgraph_type == CLUSTER:
+        return is_branched & ~topology.has_degree_2
+    raise ValueError(f"Unknown chi subgraph class {subgraph_type!r}")
 
 
-def _chi_value(
-    node_sets: list[list[int]],
-    prop_values: np.ndarray,
-    averaged: bool,
-) -> np.float32:
-    if averaged and len(node_sets) == 0:
-        return np.float32(np.nan)
+def _chi_sums(products: np.ndarray) -> tuple[np.ndarray, int]:
+    """
+    Sum of ``product over the subgraph atoms ** -0.5`` over subgraphs, for every
+    property at once, given the products of shape ``(n_props, n_subgraphs)``.
 
-    value = 0.0
-    for nodes in node_sets:
-        product = 1.0
-        for node in nodes:
-            product *= prop_values[node]
-
-        if product <= 0:
-            return np.float32(np.nan)
-
-        value += product**-0.5
-
-    if averaged:
-        value /= len(node_sets)
-
-    return np.float32(value)
+    A property whose subgraph product is non-positive anywhere sums to NaN.
+    """
+    totals = np.where((products <= 0).any(axis=1), np.nan, (products**-0.5).sum(axis=1))
+    return totals, products.shape[1]

--- a/skfp/fingerprints/_new_mordred/descriptors/chi.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/chi.py
@@ -58,19 +58,21 @@ def calc(props: AtomicProperties, subgraphs: Subgraphs) -> np.ndarray:
     prop_vals = np.stack([props.sigma_electrons.astype(float), props.valence_electrons])
 
     values = []
-    for subgraph_type, orders, prefixes in _FAMILIES:
-        for order in orders:
-            products = _subgraph_prop_products(
-                subgraphs, order, subgraph_type, prop_vals
-            )
-            totals, num_subgraphs = _chi_sums(products)
+    # properties with negative values end up as NaNs
+    with np.errstate(divide="ignore", invalid="ignore"):
+        for subgraph_type, orders, prefixes in _FAMILIES:
+            for order in orders:
+                products = _subgraph_prop_products(
+                    subgraphs, order, subgraph_type, prop_vals
+                )
+                totals, num_subgraphs = _chi_sums(products)
 
-            for prefix in prefixes:
-                averaged = prefix.startswith("A")
-                for total in totals:
-                    if averaged:
-                        total = total / num_subgraphs if num_subgraphs else np.nan
-                    values.append(total)
+                for prefix in prefixes:
+                    averaged = prefix.startswith("A")
+                    for total in totals:
+                        if averaged:
+                            total = total / num_subgraphs if num_subgraphs else np.nan
+                        values.append(total)
 
     return np.asarray(values, dtype=np.float32)
 
@@ -131,6 +133,8 @@ def _chi_sums(products: np.ndarray) -> tuple[np.ndarray, int]:
     property at once, given the products of shape ``(n_props, n_subgraphs)``.
 
     A property whose subgraph product is non-positive anywhere sums to NaN.
+    Assumes this function is wrapped in np.errstate().
     """
-    totals = np.where((products <= 0).any(axis=1), np.nan, (products**-0.5).sum(axis=1))
+    totals = (1 / np.sqrt(products)).sum(axis=1)
+    totals = np.where(np.isfinite(totals), totals, np.nan)
     return totals, products.shape[1]

--- a/skfp/fingerprints/_new_mordred/descriptors/path_count.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/path_count.py
@@ -53,8 +53,8 @@ def calc(props: AtomicProperties, subgraphs: Subgraphs) -> np.ndarray:
     pi_counts[k]: sum over those paths of the product of their bond orders
     """
     # order 0 is a lone atom: one path per atom, with no bond orders to multiply
-    path_counts = [float(props.num_atoms)]
-    pi_counts = [float(props.num_atoms)]
+    path_counts = [props.num_atoms]
+    pi_counts = [props.num_atoms]
 
     for order in range(1, MAX_ORDER + 1):
         # enumerated subgraphs (including paths) shared with Chi descriptors only
@@ -65,16 +65,20 @@ def calc(props: AtomicProperties, subgraphs: Subgraphs) -> np.ndarray:
             paths = _grow_paths(paths, subgraphs)
 
         bond_idxs = paths.bond_idxs
-        path_counts.append(float(len(bond_idxs)))
-        pi_counts.append(float(props.bond_orders[bond_idxs].prod(axis=1).sum()))
+        path_counts.append(len(bond_idxs))
+        pi_counts.append(props.bond_orders[bond_idxs].prod(axis=1).sum())
 
     # piPC starts at 1
     pi_log_counts = [np.log(pi_count + 1) for pi_count in pi_counts[1:]]
 
     values = [
-        *path_counts[2:],  # MPC starts at order 2
+        # molecular path counts, number of paths of given length
+        *path_counts[2:],
+        # total number of paths
         sum(path_counts),
+        # pi-weighted bonds, with higher weights for higher-order bonds, log-scale
         *pi_log_counts,
+        # total pi-weighted path count
         np.log(sum(pi_counts) + 1),
     ]
 

--- a/skfp/fingerprints/_new_mordred/descriptors/path_count.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/path_count.py
@@ -1,8 +1,11 @@
-import itertools
-
 import numpy as np
-from rdkit import Chem
-from rdkit.Chem import Mol
+
+from skfp.fingerprints._new_mordred.utils.atomic_properties import AtomicProperties
+from skfp.fingerprints._new_mordred.utils.subgraphs import (
+    SUBGRAPH_MAX_NUM_BONDS,
+    Paths,
+    Subgraphs,
+)
 
 """
 This code has been adapted from the BSD-licensed mordred-community library.
@@ -42,49 +45,98 @@ FEATURE_NAMES = [
 ]
 
 
-def calc(mol: Mol) -> np.ndarray:
+def calc(props: AtomicProperties, subgraphs: Subgraphs) -> np.ndarray:
     """
     Path count descriptors.
 
     path_counts[k]: number of self-avoiding paths with exactly k bonds
     pi_counts[k]: sum over those paths of the product of their bond orders
     """
-    # up to MAX_ORDER (inclusive) atoms
-    path_counts = [0.0] * (MAX_ORDER + 1)
-    pi_counts = [0.0] * (MAX_ORDER + 1)
-
-    # 0th order is a single atom
-    n_atoms = mol.GetNumAtoms()
-    path_counts[0] = n_atoms
-    pi_counts[0] = n_atoms
+    # order 0 is a lone atom: one path per atom, with no bond orders to multiply
+    path_counts = [float(props.num_atoms)]
+    pi_counts = [float(props.num_atoms)]
 
     for order in range(1, MAX_ORDER + 1):
-        # useBonds=False makes the length argument count atoms, so a path of
-        # `order` bonds spans `order + 1` atoms
-        for atoms in Chem.FindAllPathsOfLengthN(mol, length=order + 1, useBonds=False):
-            atoms = list(atoms)
-            # RDKit may return self-returning paths (e.g. around small rings)
-            # path counts only consider self-avoiding paths
-            if len(set(atoms)) != len(atoms):
-                continue
+        # enumerated subgraphs (including paths) shared with Chi descriptors only
+        # reach SUBGRAPH_MAX_NUM_BONDS, past that we need to compute paths separately
+        if order <= SUBGRAPH_MAX_NUM_BONDS:
+            paths = subgraphs.paths(order)
+        else:
+            paths = _grow_paths(paths, subgraphs)
 
-            pi = 1.0
-            for begin, end in itertools.pairwise(atoms):
-                pi *= mol.GetBondBetweenAtoms(begin, end).GetBondTypeAsDouble()
+        bond_idxs = paths.bond_idxs
+        path_counts.append(float(len(bond_idxs)))
+        pi_counts.append(float(props.bond_orders[bond_idxs].prod(axis=1).sum()))
 
-            path_counts[order] += 1
-            pi_counts[order] += pi
-
-    total_path_count = sum(path_counts)
-
-    log_pi_counts = [np.log(pi_counts[order] + 1) for order in range(1, MAX_ORDER + 1)]
-    total_log_pi_count = np.log(sum(pi_counts) + 1)
+    # piPC starts at 1
+    pi_log_counts = [np.log(pi_count + 1) for pi_count in pi_counts[1:]]
 
     values = [
-        *path_counts[2:],
-        total_path_count,
-        *log_pi_counts,
-        total_log_pi_count,
+        *path_counts[2:],  # MPC starts at order 2
+        sum(path_counts),
+        *pi_log_counts,
+        np.log(sum(pi_counts) + 1),
     ]
 
     return np.asarray(values, dtype=np.float32)
+
+
+def _grow_paths(paths: Paths, subgraphs: Subgraphs) -> Paths:
+    """
+    Extend every path by one bond, at either of its two ends.
+    """
+    halves = [_grow_at_end(paths, subgraphs, end) for end in (0, 1)]
+
+    bond_idxs = np.concatenate([half.bond_idxs for half in halves])
+    bond_idxs.sort(axis=1)  # a path is a set of bonds, so put the rows in order
+    return Paths(
+        bond_idxs,
+        np.concatenate([half.atom_idxs for half in halves]),
+        np.concatenate([half.end_atoms for half in halves]),
+    )
+
+
+def _grow_at_end(paths: Paths, subgraphs: Subgraphs, end: int) -> Paths:
+    """
+    Extend every path by one bond at one nominated end, ``end`` being 0 or 1.
+
+    Some paths yield several extensions and some none, so the result has its own
+    number of rows and its own ordering.
+    """
+    bond_idxs, atom_idxs = paths.bond_idxs, paths.atom_idxs
+    end_atoms = paths.end_atoms
+    grown_atoms = end_atoms[:, end]
+
+    # calculate bonds from a given atom as candidates to grow a path
+    incident = subgraphs.bonds_of_atom[grown_atoms]
+    is_bond = incident >= 0  # the rest is padding
+
+    # flatten rows into one candidate bond per entry
+    # path_of[i] is the path that candidates[i] would extend
+    path_of, slot_of = np.nonzero(is_bond)
+    candidates = incident[path_of, slot_of]
+
+    # a bond holds both of its atoms, so subtracting the one being grown from
+    # leaves the atom on the far side: the one this extension would add
+    new_atoms = subgraphs.bond_atoms[candidates].sum(axis=1) - grown_atoms[path_of]
+
+    # reject already visited atoms and bonds
+    atoms_on_path = atom_idxs[path_of]  # (n_candidates, n_atoms_per_path)
+    self_avoiding = (atoms_on_path != new_atoms[:, None]).all(axis=1)
+
+    # a grown path ends at the atom just added, and at the end left alone
+    # either of those two could have been the one added last, which is ambiguous
+    # requiring the added atom to have lower number removes potential duplicates
+    other_end = end_atoms[path_of, 1 - end]
+    keep = self_avoiding & (new_atoms < other_end)
+
+    candidates, path_of = candidates[keep], path_of[keep]
+    new_atoms, other_end = new_atoms[keep], other_end[keep]
+
+    return Paths(
+        # each survivor inherits its parent's bonds and atoms, plus the ones added
+        np.concatenate([bond_idxs[path_of], candidates[:, None]], axis=1),
+        np.concatenate([atom_idxs[path_of], new_atoms[:, None]], axis=1),
+        # the grown end moved to the atom just added; the other end stayed put
+        np.stack([new_atoms, other_end], axis=1),
+    )

--- a/skfp/fingerprints/_new_mordred/descriptors/polarizability.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/polarizability.py
@@ -16,6 +16,7 @@ def calc(atomic_props_hydrogens: AtomicProperties) -> np.ndarray:
     polarizabilities = atomic_props_hydrogens.get("polarizability")
 
     atom_polarizability = polarizabilities.sum()
+
     bond_polarizability = np.abs(
         polarizabilities[atomic_props_hydrogens.bond_begin_idxs]
         - polarizabilities[atomic_props_hydrogens.bond_end_idxs]

--- a/skfp/fingerprints/_new_mordred/descriptors/rdkit_descriptors.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/rdkit_descriptors.py
@@ -1,3 +1,12 @@
+"""
+Mordred descriptors implemented as direct RDKit wrappers.
+
+This code has been adapted from the BSD-licensed mordred-community library.
+https://github.com/JacksonBurns/mordred-community
+
+See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
+"""
+
 import numpy as np
 from rdkit.Chem import (
     Crippen,
@@ -11,15 +20,6 @@ from rdkit.Chem.EState import EState_VSA
 
 from skfp.fingerprints._new_mordred.utils.descriptor_evaluation import safe_value
 from skfp.fingerprints._new_mordred.utils.graph_matrix import DistanceMatrix
-
-"""
-Mordred descriptors implemented as direct RDKit wrappers.
-
-This code has been adapted from the BSD-licensed mordred-community library.
-https://github.com/JacksonBurns/mordred-community
-
-See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
-"""
 
 FEATURE_NAMES_2D = [
     "BalabanJ",

--- a/skfp/fingerprints/_new_mordred/descriptors/rdkit_descriptors.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/rdkit_descriptors.py
@@ -1,12 +1,3 @@
-"""
-Mordred descriptors implemented as direct RDKit wrappers.
-
-This code has been adapted from the BSD-licensed mordred-community library.
-https://github.com/JacksonBurns/mordred-community
-
-See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
-"""
-
 import numpy as np
 from rdkit.Chem import (
     Crippen,
@@ -20,6 +11,13 @@ from rdkit.Chem.EState import EState_VSA
 
 from skfp.fingerprints._new_mordred.utils.descriptor_evaluation import safe_value
 from skfp.fingerprints._new_mordred.utils.graph_matrix import DistanceMatrix
+
+"""
+This code has been adapted from the BSD-licensed mordred-community library.
+https://github.com/JacksonBurns/mordred-community
+
+See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
+"""
 
 FEATURE_NAMES_2D = [
     "BalabanJ",

--- a/skfp/fingerprints/_new_mordred/descriptors/rotatable_bond.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/rotatable_bond.py
@@ -1,6 +1,3 @@
-import numpy as np
-from rdkit.Chem import Mol, rdMolDescriptors
-
 """
 Rotatable bond descriptors implemented with RDKit bond counters.
 
@@ -9,6 +6,9 @@ https://github.com/JacksonBurns/mordred-community
 
 See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
 """
+
+import numpy as np
+from rdkit.Chem import Mol, rdMolDescriptors
 
 FEATURE_NAMES = ["nRot", "RotRatio"]
 

--- a/skfp/fingerprints/_new_mordred/descriptors/rotatable_bond.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/rotatable_bond.py
@@ -1,14 +1,12 @@
-"""
-Rotatable bond descriptors implemented with RDKit bond counters.
+import numpy as np
+from rdkit.Chem import Mol, rdMolDescriptors
 
+"""
 This code has been adapted from the BSD-licensed mordred-community library.
 https://github.com/JacksonBurns/mordred-community
 
 See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
 """
-
-import numpy as np
-from rdkit.Chem import Mol, rdMolDescriptors
 
 FEATURE_NAMES = ["nRot", "RotRatio"]
 

--- a/skfp/fingerprints/_new_mordred/utils/descriptor_evaluation.py
+++ b/skfp/fingerprints/_new_mordred/utils/descriptor_evaluation.py
@@ -1,16 +1,14 @@
-"""
-Shared helpers for Mordred descriptor calculations.
+from collections.abc import Callable
+from typing import Any
 
+import numpy as np
+
+"""
 This code has been adapted from the BSD-licensed mordred-community library.
 https://github.com/JacksonBurns/mordred-community
 
 See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
 """
-
-from collections.abc import Callable
-from typing import Any
-
-import numpy as np
 
 
 def safe_value(func: Callable[..., float | int], *args: Any, **kwargs: Any) -> float:

--- a/skfp/fingerprints/_new_mordred/utils/feature_names.py
+++ b/skfp/fingerprints/_new_mordred/utils/feature_names.py
@@ -6,7 +6,7 @@ https://github.com/JacksonBurns/mordred-community
 See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
 """
 
-# 2D descriptors, in the order mordred lists them
+# 2D descriptors
 FEATURE_NAMES_2D = [
     "ABC",
     "ABCGG",
@@ -1623,7 +1623,7 @@ FEATURE_NAMES_2D = [
     "mZagreb2",
 ]
 
-# descriptors that need a conformer, in the order mordred lists them
+# 3D, conformer-based descriptors
 FEATURE_NAMES_3D = [
     "PNSA1",
     "PNSA2",
@@ -1840,6 +1840,4 @@ FEATURE_NAMES_3D = [
     "PBF",
 ]
 
-# the 3D output appends the conformer descriptors to the 2D ones, so a 2D feature
-# sits at the same position whether or not the 3D ones are computed
 ALL_FEATURE_NAMES = FEATURE_NAMES_2D + FEATURE_NAMES_3D

--- a/skfp/fingerprints/_new_mordred/utils/feature_names.py
+++ b/skfp/fingerprints/_new_mordred/utils/feature_names.py
@@ -1,10 +1,7 @@
-"""
-Code has been adapted from the BSD-licensed mordred-community library.
-
-https://github.com/JacksonBurns/mordred-community
-
-See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
-"""
+# This code has been adapted from the BSD-licensed mordred-community library.
+# https://github.com/JacksonBurns/mordred-community
+#
+# See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
 
 # 2D descriptors
 FEATURE_NAMES_2D = [

--- a/skfp/fingerprints/_new_mordred/utils/subgraphs.py
+++ b/skfp/fingerprints/_new_mordred/utils/subgraphs.py
@@ -1,0 +1,379 @@
+from dataclasses import dataclass
+
+import numpy as np
+
+from skfp.fingerprints._new_mordred.utils.atomic_properties import AtomicProperties
+
+"""
+This code has been adapted from the BSD-licensed mordred-community library.
+https://github.com/JacksonBurns/mordred-community
+
+See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
+"""
+
+# NOTE: subgraph order = its number of bonds
+
+# connected subgraphs up to this many bonds, the largest order the
+# chi descriptors use
+SUBGRAPH_MAX_NUM_BONDS = 7
+
+
+@dataclass
+class Paths:
+    """
+    A set of self-avoiding paths spanning the same number of bonds.
+
+    Bonds ascend within each row. Atoms are in no particular order.
+    A path spans one atom more than it has bonds, so its atoms form
+    one rectangular block.
+    """
+
+    bond_idxs: np.ndarray  # (n_paths, order)
+    atom_idxs: np.ndarray  # (n_paths, order + 1)
+    end_atoms: np.ndarray  # (n_paths, 2)
+
+
+class SubgraphsTopology:
+    """
+    Topological properties for all connected subgraphs of one order (size).
+
+    Holds, for each subgraph:
+    - the atoms it spans
+    - whether it closes a cycle
+    - how branched it is
+
+    Those are mask arrays, e.g. ``is_cyclic[i]``.
+    """
+
+    def __init__(
+        self,
+        atoms: np.ndarray,
+        atom_offsets: np.ndarray,
+        atom_counts: np.ndarray,
+        is_cyclic: np.ndarray,
+        max_degree: np.ndarray,
+        has_degree_2: np.ndarray,
+    ):
+        # the atoms of every subgraph, concatenated; a subgraph's own atoms are
+        # the run of atom_counts entries starting at its atom_offsets entry
+        self._atoms = atoms
+        self._atom_offsets = atom_offsets
+        self._atom_counts = atom_counts
+
+        # the three per-subgraph arrays below all have shape (n_subgraphs,)
+        self.is_cyclic = is_cyclic
+        self.max_degree = max_degree
+        self.has_degree_2 = has_degree_2
+
+    @property
+    def is_path(self) -> np.ndarray:
+        """
+        Path = acyclic and unbranched.
+        """
+        return ~self.is_cyclic & (self.max_degree <= 2)
+
+    def atom_idxs(self, subgraph_idx: int) -> np.ndarray:
+        """
+        Get the atoms one subgraph spans, the run of ``atom_counts`` entries that
+        it owns.
+        """
+        start = self._atom_offsets[subgraph_idx]
+        return self._atoms[start : start + self._atom_counts[subgraph_idx]]
+
+    def atom_products(self, values: np.ndarray) -> np.ndarray:
+        """
+        Product of each row of ``values``, an array of shape (n_rows, n_atoms),
+        over the atoms of every subgraph, shape (n_rows, n_subgraphs).
+
+        Subgraphs of one order need not span equally many atoms, so their atoms
+        are kept flat and multiplied one run at a time.
+        """
+        return np.multiply.reduceat(values[:, self._atoms], self._atom_offsets, axis=1)
+
+
+class Subgraphs:
+    """
+    Connected subgraphs of a molecule, as arrays of bond indices.
+
+    The subgraphs come from the ESU recursion in ``_enumerate_subgraphs()``.
+    This algorithm is quite a bit faster than using RDKit.
+    """
+
+    def __init__(self, props: AtomicProperties):
+        # atom indices of the two ends of every bond, shape (n_bonds, 2)
+        self._bond_atoms = np.stack(
+            [props.bond_begin_idxs, props.bond_end_idxs], axis=1
+        )
+        self._num_atoms = props.num_atoms
+        self._num_bonds = props.num_bonds
+
+        # atom indices of the two ends of every bond, shape (n_bonds, 2)
+        self.bond_atoms = self._bond_atoms
+        # which bonds each atom takes part in
+        self.bonds_of_atom = self._build_atom_adjacency()
+
+        # which bonds share an atom
+        self._bonds_share_atom = self._line_graph_neighbors(
+            self._bond_atoms, self.bonds_of_atom
+        )
+
+        # order -> bond indexes
+        self._subgraph_cache: dict[int, np.ndarray] = {}
+
+        # order -> topological info
+        self._analyzed_cache: dict[int, tuple[SubgraphsTopology, Paths]] = {}
+
+    def topology(self, order: int) -> SubgraphsTopology:
+        """
+        Graph topology info for all subgraphs with a given order (number of bonds).
+        """
+        topology, _ = self._calculate_topology_and_paths(order)
+        return topology
+
+    def paths(self, order: int) -> Paths:
+        """
+        Select all paths of a given order (length, number of bonds), up to
+        ``SUBGRAPH_MAX_NUM_BONDS``.
+        """
+        _, paths = self._calculate_topology_and_paths(order)
+        return paths
+
+    def _build_atom_adjacency(self) -> np.ndarray:
+        """
+        Bonds incident to each atom, array of shape (n_atoms, max_atom_degree).
+
+        Unused cells for lower-degree atoms get value -1.
+        """
+        degrees = np.bincount(self._bond_atoms.ravel(), minlength=self._num_atoms)
+        max_degree = int(degrees.max()) if degrees.size else 0
+        bonds_of_atom = np.full((self._num_atoms, max_degree), -1, dtype=np.intp)
+
+        # filling row by row keeps each atom's bonds in ascending order
+        next_slot = np.zeros(self._num_atoms, dtype=np.intp)
+        for bond, (begin, end) in enumerate(self._bond_atoms):
+            for atom in (begin, end):
+                bonds_of_atom[atom, next_slot[atom]] = bond
+                next_slot[atom] += 1
+
+        return bonds_of_atom
+
+    def _subgraph_bond_idxs(self, order: int) -> np.ndarray:
+        """
+        Bond indices of every connected subgraph with ``order`` bonds, ascending
+        within each row, shape ``(n_subgraphs, order)``.
+        """
+        if not self._subgraph_cache:
+            # every order is enumerated in one pass, since each is grown from previous one
+            self._subgraph_cache = self._enumerate_subgraphs(
+                self._bonds_share_atom, self._num_bonds, SUBGRAPH_MAX_NUM_BONDS
+            )
+
+        return self._subgraph_cache[order]
+
+    def _calculate_topology_and_paths(
+        self, order: int
+    ) -> tuple[SubgraphsTopology, Paths]:
+        """
+        Analyze the subgraphs of a given order, calculating topology and paths.
+        """
+        if order not in self._analyzed_cache:
+            self._analyzed_cache[order] = self._topology_and_paths(
+                self._subgraph_bond_idxs(order), self._bond_atoms, order
+            )
+        return self._analyzed_cache[order]
+
+    @staticmethod
+    def _line_graph_neighbors(
+        bond_atoms: np.ndarray, bonds_of_atom: np.ndarray
+    ) -> list[set[int]]:
+        """
+        For every bond, the bonds that share an atom with it.
+
+        Calculates line graph (https://en.wikipedia.org/wiki/Line_graph),
+        whose nodes are molecule bonds. Connected subgraph in a molecule
+        is a set of bonds connected in a line graph. Thus, this representation
+        allows quick enumeration.
+        """
+        neighbors = []
+        for bond, (begin, end) in enumerate(bond_atoms):
+            # a bond touches every bond sitting at either of its two atoms
+            shared = set(bonds_of_atom[begin].tolist())
+            shared.update(bonds_of_atom[end].tolist())
+            shared.discard(bond)
+            shared.discard(-1)  # padding of the lower-degree atoms
+            neighbors.append(shared)
+        return neighbors
+
+    @staticmethod
+    def _enumerate_subgraphs(
+        neighbors: list[set[int]], num_bonds: int, max_order: int
+    ) -> dict[int, np.ndarray]:
+        """
+        Enumerate connected subgraphs up to ``max_order`` bonds.
+
+        Returns dict: order -> bond indices of each subgraph, shape (n_subgraphs, order)
+
+        Subgraph enumeration uses ESU algorithm Wernicke, "Efficient detection of
+        network motifs"), which fixes for each subgraph a single order in which
+        it may be built:
+
+        - the lowest-numbered bond of a subgraph is its root
+        - only bonds above the root are added, so a subgraph can only grow from
+          its own lowest bond
+        - when a bond is added, the bonds already considered stay, and the only
+          bonds joining them are those that the added bond reaches on its own - a bond
+          already touching the subgraph was considered before and was passed over
+
+        The last rule is what stops one set of bonds from being reached by adding its
+        bonds in different orders: passing over a bond drops it from that branch for
+        good.
+        """
+        by_order: dict[int, list[tuple[int, ...]]] = {
+            order: [] for order in range(1, max_order + 1)
+        }
+
+        def grow(subgraph: list[int], offered: set[int], root: int) -> None:
+            by_order[len(subgraph)].append(tuple(sorted(subgraph)))
+            if len(subgraph) == max_order:
+                return
+
+            # the bonds the subgraph can already reach; whatever the next bond adds has
+            # to lie beyond these, since these were on offer before and were declined
+            touching = set().union(*(neighbors[bond] for bond in subgraph))
+
+            # popping from a copy makes a declined bond stay declined for this branch,
+            # while each child gets its own offer set to work through
+            offered = set(offered)
+            while offered:
+                added = offered.pop()
+                newly_reachable = {
+                    bond
+                    for bond in neighbors[added]
+                    if bond > root and bond not in subgraph and bond not in touching
+                }
+                grow([*subgraph, added], offered | newly_reachable, root)
+
+        for root_bond in range(num_bonds):
+            above_root = {bond for bond in neighbors[root_bond] if bond > root_bond}
+            grow([root_bond], above_root, root_bond)
+
+        return {
+            order: (
+                np.array(rows, dtype=np.intp)
+                if rows
+                else np.empty((0, order), dtype=np.intp)
+            )
+            for order, rows in by_order.items()
+        }
+
+    @classmethod
+    def _topology_and_paths(
+        cls, bond_idxs: np.ndarray, bond_atoms: np.ndarray, order: int
+    ) -> tuple[SubgraphsTopology, Paths]:
+        """
+        Describe the shape of every connected subgraph with ``order`` bonds and pick
+        the paths out of them. Both can be computed in a single pass.
+        """
+        num_subgraphs = len(bond_idxs)
+        if num_subgraphs == 0:
+            empty = np.empty(0, dtype=np.intp)
+            no_flags = np.empty(0, dtype=bool)
+            topology = SubgraphsTopology(empty, empty, empty, no_flags, empty, no_flags)
+            return topology, cls._no_paths(order)
+
+        # atoms at ends of subgraph's bonds
+        # sorted within each subgraph, so that repeats of an atom land next to each other
+        # shape ``(n_subgraphs, 2 * order)``
+        row_width = 2 * order
+        endpoints = np.sort(
+            bond_atoms[bond_idxs].reshape(num_subgraphs, row_width), axis=1
+        ).ravel()
+
+        # one run of equal atom indices is one atom of the subgraph, and the length of
+        # the run is how many of the subgraph's bonds meet at that atom
+        is_run_start = np.ones(endpoints.shape, dtype=bool)
+        is_run_start[1:] = endpoints[1:] != endpoints[:-1]
+        is_run_start[::row_width] = True  # a run never spans two subgraphs
+        run_start_idxs = np.flatnonzero(is_run_start)
+        degrees = np.diff(run_start_idxs, append=endpoints.size)
+        subgraph_of_run = run_start_idxs // row_width
+
+        atoms = endpoints[run_start_idxs]
+        atom_counts = np.bincount(subgraph_of_run, minlength=num_subgraphs)
+        atom_offsets = cls._run_starts(atom_counts)
+
+        is_cyclic = order >= atom_counts
+        has_degree_2 = (
+            np.bincount(subgraph_of_run, weights=degrees == 2, minlength=num_subgraphs)
+            > 0
+        )
+
+        topology = SubgraphsTopology(
+            atoms,
+            atom_offsets,
+            atom_counts,
+            is_cyclic=is_cyclic,
+            max_degree=np.maximum.reduceat(degrees, atom_offsets),
+            has_degree_2=has_degree_2,
+        )
+        paths = cls._extract_paths(
+            bond_idxs, topology, atoms, atom_offsets, degrees, order
+        )
+        return topology, paths
+
+    @classmethod
+    def _extract_paths(
+        cls,
+        bond_idxs: np.ndarray,
+        topology: SubgraphsTopology,
+        atoms: np.ndarray,
+        atom_offsets: np.ndarray,
+        degrees: np.ndarray,
+        order: int,
+    ) -> Paths:
+        """
+        Read the paths from the subgraphs.
+
+        A path spans exactly ``order + 1`` atoms, so its atoms form one rectangular
+        block of shape ``(n_paths, order + 1)``. It ends at the two atoms that only
+        one of its bonds touches.
+        """
+        path_rows = np.flatnonzero(topology.is_path)
+        if not len(path_rows):
+            return cls._no_paths(order)
+
+        within_path = np.arange(order + 1)
+        path_starts = atom_offsets[path_rows][:, np.newaxis]
+        path_atoms = atoms[path_starts + within_path]
+        path_degrees = degrees[path_starts + within_path]
+        end_atoms = path_atoms[path_degrees == 1].reshape(len(path_rows), 2)
+        return Paths(
+            bond_idxs=bond_idxs[path_rows],
+            atom_idxs=path_atoms,
+            end_atoms=end_atoms,
+        )
+
+    @staticmethod
+    def _no_paths(order: int) -> Paths:
+        """
+        Empty paths, to handle case with no paths found.
+        """
+        return Paths(
+            bond_idxs=np.empty((0, order), dtype=np.intp),
+            atom_idxs=np.empty((0, order + 1), dtype=np.intp),
+            end_atoms=np.empty((0, 2), dtype=np.intp),
+        )
+
+    @staticmethod
+    def _run_starts(counts: np.ndarray) -> np.ndarray:
+        """
+        Since we use flattened 2D arrays for speed, we need to get where each row
+        actually starts. Calculcated as a prefix sum of lengths.
+
+        E.g. for counts = [3, 0, 2] this is [0, 3, 3] - rows 1 and 2 share a start
+        offset because row 1 is empty.
+        """
+        # cumsum gives each row's end, i.e. the inclusive prefix sum
+        # subtracting the row's own length turns that into its start
+        row_ends = np.cumsum(counts)
+        return row_ends - counts

--- a/skfp/fingerprints/_new_mordred/utils/subgraphs.py
+++ b/skfp/fingerprints/_new_mordred/utils/subgraphs.py
@@ -101,42 +101,45 @@ class Subgraphs:
 
     def __init__(self, props: AtomicProperties):
         # atom indices of the two ends of every bond, shape (n_bonds, 2)
-        self._bond_atoms = np.stack(
-            [props.bond_begin_idxs, props.bond_end_idxs], axis=1
-        )
+        self.bond_atoms = np.stack([props.bond_begin_idxs, props.bond_end_idxs], axis=1)
         self._num_atoms = props.num_atoms
-        self._num_bonds = props.num_bonds
 
-        # atom indices of the two ends of every bond, shape (n_bonds, 2)
-        self.bond_atoms = self._bond_atoms
         # which bonds each atom takes part in
         self.bonds_of_atom = self._build_atom_adjacency()
 
         # which bonds share an atom
-        self._bonds_share_atom = self._line_graph_neighbors(
-            self._bond_atoms, self.bonds_of_atom
+        bonds_share_atom = self._line_graph_neighbors(
+            self.bond_atoms, self.bonds_of_atom
         )
 
-        # order -> bond indexes
-        self._subgraph_cache: dict[int, np.ndarray] = {}
+        # bond indexes of every subgraph, one entry per order
+        # every order is enumerated in one pass, since each is grown from previous one
+        subgraphs = self._enumerate_subgraphs(
+            bonds_share_atom, props.num_bonds, SUBGRAPH_MAX_NUM_BONDS
+        )
 
-        # order -> topological info
-        self._analyzed_cache: dict[int, tuple[SubgraphsTopology, Paths]] = {}
+        # topology and paths of every subgraph, one tuple for each
+        # both hold one entry per order, indexed by order - 1, since order 0 has
+        # no bonds and is never enumerated
+        analyzed = [
+            self._topology_and_paths(bond_idxs, self.bond_atoms, order)
+            for order, bond_idxs in enumerate(subgraphs, start=1)
+        ]
+        self._topologies = tuple(topology for topology, _ in analyzed)
+        self._paths = tuple(paths for _, paths in analyzed)
 
     def topology(self, order: int) -> SubgraphsTopology:
         """
         Graph topology info for all subgraphs with a given order (number of bonds).
         """
-        topology, _ = self._calculate_topology_and_paths(order)
-        return topology
+        return self._topologies[order - 1]
 
     def paths(self, order: int) -> Paths:
         """
         Select all paths of a given order (length, number of bonds), up to
         ``SUBGRAPH_MAX_NUM_BONDS``.
         """
-        _, paths = self._calculate_topology_and_paths(order)
-        return paths
+        return self._paths[order - 1]
 
     def _build_atom_adjacency(self) -> np.ndarray:
         """
@@ -144,43 +147,18 @@ class Subgraphs:
 
         Unused cells for lower-degree atoms get value -1.
         """
-        degrees = np.bincount(self._bond_atoms.ravel(), minlength=self._num_atoms)
+        degrees = np.bincount(self.bond_atoms.ravel(), minlength=self._num_atoms)
         max_degree = int(degrees.max()) if degrees.size else 0
         bonds_of_atom = np.full((self._num_atoms, max_degree), -1, dtype=np.intp)
 
         # filling row by row keeps each atom's bonds in ascending order
         next_slot = np.zeros(self._num_atoms, dtype=np.intp)
-        for bond, (begin, end) in enumerate(self._bond_atoms):
+        for bond, (begin, end) in enumerate(self.bond_atoms):
             for atom in (begin, end):
                 bonds_of_atom[atom, next_slot[atom]] = bond
                 next_slot[atom] += 1
 
         return bonds_of_atom
-
-    def _subgraph_bond_idxs(self, order: int) -> np.ndarray:
-        """
-        Bond indices of every connected subgraph with ``order`` bonds, ascending
-        within each row, shape ``(n_subgraphs, order)``.
-        """
-        if not self._subgraph_cache:
-            # every order is enumerated in one pass, since each is grown from previous one
-            self._subgraph_cache = self._enumerate_subgraphs(
-                self._bonds_share_atom, self._num_bonds, SUBGRAPH_MAX_NUM_BONDS
-            )
-
-        return self._subgraph_cache[order]
-
-    def _calculate_topology_and_paths(
-        self, order: int
-    ) -> tuple[SubgraphsTopology, Paths]:
-        """
-        Analyze the subgraphs of a given order, calculating topology and paths.
-        """
-        if order not in self._analyzed_cache:
-            self._analyzed_cache[order] = self._topology_and_paths(
-                self._subgraph_bond_idxs(order), self._bond_atoms, order
-            )
-        return self._analyzed_cache[order]
 
     @staticmethod
     def _line_graph_neighbors(
@@ -207,11 +185,12 @@ class Subgraphs:
     @staticmethod
     def _enumerate_subgraphs(
         neighbors: list[set[int]], num_bonds: int, max_order: int
-    ) -> dict[int, np.ndarray]:
+    ) -> tuple[np.ndarray, ...]:
         """
         Enumerate connected subgraphs up to ``max_order`` bonds.
 
-        Returns dict: order -> bond indices of each subgraph, shape (n_subgraphs, order)
+        Returns one entry per order, indexed by order - 1: the bond indices of each
+        subgraph of that order, shape (n_subgraphs, order)
 
         Subgraph enumeration uses ESU algorithm Wernicke, "Efficient detection of
         network motifs"), which fixes for each subgraph a single order in which
@@ -228,22 +207,22 @@ class Subgraphs:
         bonds in different orders: passing over a bond drops it from that branch for
         good.
         """
-        by_order: dict[int, list[tuple[int, ...]]] = {
-            order: [] for order in range(1, max_order + 1)
-        }
+        by_order: list[list[tuple[int, ...]]] = [[] for _ in range(max_order)]
 
-        def grow(subgraph: list[int], offered: set[int], root: int) -> None:
-            by_order[len(subgraph)].append(tuple(sorted(subgraph)))
+        # ``touching`` is the bonds the subgraph can already reach; whatever the next
+        # bond adds has to lie beyond these, since these were on offer before and were
+        # declined. It is threaded through rather than recomputed, since a subgraph
+        # reaches exactly what its parent reached plus what the added bond reaches
+        def grow(
+            subgraph: list[int], offered: set[int], touching: set[int], root: int
+        ) -> None:
+            by_order[len(subgraph) - 1].append(tuple(sorted(subgraph)))
             if len(subgraph) == max_order:
                 return
 
-            # the bonds the subgraph can already reach; whatever the next bond adds has
-            # to lie beyond these, since these were on offer before and were declined
-            touching = set().union(*(neighbors[bond] for bond in subgraph))
-
             # popping from a copy makes a declined bond stay declined for this branch,
             # while each child gets its own offer set to work through
-            offered = set(offered)
+            offered = offered.copy()
             while offered:
                 added = offered.pop()
                 newly_reachable = {
@@ -251,20 +230,26 @@ class Subgraphs:
                     for bond in neighbors[added]
                     if bond > root and bond not in subgraph and bond not in touching
                 }
-                grow([*subgraph, added], offered | newly_reachable, root)
+                # adding a bond extends the reach of the subgraph by its own
+                grow(
+                    [*subgraph, added],
+                    offered | newly_reachable,
+                    touching | neighbors[added],
+                    root,
+                )
 
         for root_bond in range(num_bonds):
             above_root = {bond for bond in neighbors[root_bond] if bond > root_bond}
-            grow([root_bond], above_root, root_bond)
+            grow([root_bond], above_root, neighbors[root_bond], root_bond)
 
-        return {
-            order: (
-                np.array(rows, dtype=np.intp)
-                if rows
-                else np.empty((0, order), dtype=np.intp)
-            )
-            for order, rows in by_order.items()
-        }
+        result = tuple(
+            np.array(rows, dtype=np.intp)
+            if rows
+            else np.empty((0, order), dtype=np.intp)
+            for order, rows in enumerate(by_order, start=1)
+        )
+
+        return result
 
     @classmethod
     def _topology_and_paths(
@@ -281,27 +266,30 @@ class Subgraphs:
             topology = SubgraphsTopology(empty, empty, empty, no_flags, empty, no_flags)
             return topology, cls._no_paths(order)
 
-        # atoms at ends of subgraph's bonds
-        # sorted within each subgraph, so that repeats of an atom land next to each other
-        # shape ``(n_subgraphs, 2 * order)``
+        # the two atoms of each subgraph bond, one row per subgraph, sorted within the
+        # row so that repeats of an atom land next to each other, then flattened
         row_width = 2 * order
         endpoints = np.sort(
             bond_atoms[bond_idxs].reshape(num_subgraphs, row_width), axis=1
         ).ravel()
 
-        # one run of equal atom indices is one atom of the subgraph, and the length of
-        # the run is how many of the subgraph's bonds meet at that atom
+        # one run of equal atoms is one atom of the subgraph, its length that atom's
+        # degree within the subgraph
         is_run_start = np.ones(endpoints.shape, dtype=bool)
         is_run_start[1:] = endpoints[1:] != endpoints[:-1]
-        is_run_start[::row_width] = True  # a run never spans two subgraphs
+        is_run_start[::row_width] = True  # rows are back to back, a run spans only one
         run_start_idxs = np.flatnonzero(is_run_start)
+
+        # one entry per run, i.e. per (subgraph, atom), the runs of a subgraph adjacent
         degrees = np.diff(run_start_idxs, append=endpoints.size)
         subgraph_of_run = run_start_idxs // row_width
-
         atoms = endpoints[run_start_idxs]
+
+        # ragged view: subgraph i owns atom_counts[i] entries from atom_offsets[i]
         atom_counts = np.bincount(subgraph_of_run, minlength=num_subgraphs)
         atom_offsets = cls._run_starts(atom_counts)
 
+        # a tree has one bond fewer than atoms, so no fewer means a cycle
         is_cyclic = order >= atom_counts
         has_degree_2 = (
             np.bincount(subgraph_of_run, weights=degrees == 2, minlength=num_subgraphs)

--- a/tests/fingerprints/_new_mordred/chi.py
+++ b/tests/fingerprints/_new_mordred/chi.py
@@ -10,7 +10,9 @@ from skfp.fingerprints._new_mordred.descriptors.chi import (
     FEATURE_NAMES,
     calc,
 )
+from skfp.fingerprints._new_mordred.utils.atomic_properties import AtomicProperties
 from skfp.fingerprints._new_mordred.utils.mol_preprocess import preprocess_mol
+from skfp.fingerprints._new_mordred.utils.subgraphs import Subgraphs
 
 """
 This code has been adapted from the BSD-licensed mordred-community library.
@@ -54,7 +56,8 @@ def computed_values():
     computed = {}
     for name, smiles in _SMILES.items():
         mol = preprocess_mol(MolFromSmiles(smiles))
-        values = calc(mol)
+        props = AtomicProperties.from_mol(mol)
+        values = calc(props, Subgraphs(props))
         computed[name] = dict(zip(FEATURE_NAMES, values, strict=True))
     return computed
 

--- a/tests/fingerprints/_new_mordred/path_count.py
+++ b/tests/fingerprints/_new_mordred/path_count.py
@@ -5,7 +5,9 @@ from numpy.testing import assert_allclose
 from skfp.fingerprints._new_mordred.descriptors.path_count import (
     calc,
 )
+from skfp.fingerprints._new_mordred.utils.atomic_properties import AtomicProperties
 from skfp.fingerprints._new_mordred.utils.mol_preprocess import preprocess_mol
+from skfp.fingerprints._new_mordred.utils.subgraphs import Subgraphs
 
 """
 This code has been adapted from the BSD-licensed mordred-community library.
@@ -335,5 +337,6 @@ See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license tex
 def test_path_count_values(name, expected, mordred_test_mols):
     mol_regular = preprocess_mol(mordred_test_mols[name])
 
-    values = calc(mol_regular)
+    props = AtomicProperties.from_mol(mol_regular)
+    values = calc(props, Subgraphs(props))
     assert_allclose(values, np.asarray(expected, dtype=np.float32), rtol=1e-5)


### PR DESCRIPTION
The chi and path count descriptors each enumerated the connected subgraphs of
the molecule themselves, in Python, one subgraph at a time - together the
largest cost in the whole calculator, around 29% of its Python time. Subgraphs
enumerates them once per molecule: subgraphs of each order are grown from
those of the previous order by adding one adjacent bond, entirely with array
operations over flat index arrays.

- utils/subgraphs.py enumerates up to order 7, the largest the chi descriptors
  ask for, and classifies each subgraph as chain, path, path cluster or
  cluster
- the atom index sets of a type are gathered only when a descriptor asks for
  them, since chi wants different types at different orders
- utils/ragged.py holds the two helpers for rows of unequal length that this
  bookkeeping needs
- chi and path_count read the shared Subgraphs and the shared properties

Computing all 2D descriptors for 400 molecules drops from 19.5s to 8.5s.

Values are unchanged except for 54 chi columns (Xc, Xch, Xp, Xpc, AXp), which
differ by up to 3.4e-6 relative on 300 molecules sampled from MoleculeNet,
TDC and MoleculeACE - float32 rounding from summing the per-subgraph terms in
a different order.

---

Splits up #661 into reviewable pieces. Based on `mordred-opt-05-ring-sets` - review and merge in order.

<details>
<summary>The stack</summary>

1. #665 - feature names resolved per module
2. #666 - AtomicProperties
3. #667 - hydrogen-explicit matrices derived
4. #668 - spectral attributes over a stack
5. #669 - RingSets
6. #670 - subgraph enumeration (chi, path counts)  **<- this PR**
7. #671 - detour matrix
8. #672 - ETA descriptors
9. #673 - autocorrelations
10. #674 - Barysz matrices
11. #675 - E-state indices shared with VSA
12. #676 - BCUT (not computed before)
13. #677 - walk counts
14. #678 - conformer descriptors
15. #679 - atom, bond and constitutional counts
16. #680 - topological charge and Zagreb
17. #681 - ABC and molecular distance edge
</details>
