### PR TITLE
Mordred: compute the BCUT descriptors

### DIFF
--- a/skfp/fingerprints/_new_mordred/calculator.py
+++ b/skfp/fingerprints/_new_mordred/calculator.py
@@ -254,7 +254,7 @@ def compute(mol: Mol, use_3D: bool) -> np.ndarray:
             n_frags,
         ),
         barysz_matrix: barysz_matrix.calc(props_regular, n_frags),
-        bcut: bcut.calc(mol_regular),
+        bcut: bcut.calc(props_regular, n_frags),
         aromatic: aromatic.calc(props_regular),
         topological_charge: topological_charge.calc(
             adjacency_matrix_regular, distance_matrix_regular

--- a/skfp/fingerprints/_new_mordred/descriptors/bcut.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/bcut.py
@@ -1,21 +1,9 @@
 import numpy as np
-from rdkit.Chem import GetMolFrags, Mol
 
 from skfp.fingerprints._new_mordred.utils.atomic_properties import (
-    gasteiger_charges,
-    get_allred_rochow_electronegativity,
-    get_atomic_number,
-    get_intrinsic_state,
-    get_ionization_potential,
-    get_mass,
-    get_pauling_electronegativity,
-    get_polarizability,
-    get_sanderson_electronegativity,
-    get_sigma_electrons,
-    get_valence_electrons,
-    get_van_der_waals_volume,
+    WEIGHTING_PROPERTY_NAMES,
+    AtomicProperties,
 )
-from skfp.fingerprints._new_mordred.utils.mol_preprocess import atoms_apply_func
 
 """
 This code has been adapted from the BSD-licensed mordred-community library.
@@ -25,93 +13,62 @@ See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license tex
 """
 
 
-# atomic properties used to weight distance matrices
-_PROPS_NAMES = [
-    "atomic_number",
-    "mass",
-    "van_der_Waals_volume",
-    "Sanderson_electronegativity",
-    "Pauling_electronegativity",
-    "Allred_Rochow_electronegativity",
-    "polarizability",
-    "ionization_potential",
-    "valence_electrons",
-    "sigma_electrons",  # http://dx.doi.org/10.1002%2Fjps.2600721016
-    "intrinsic_state",  # http://www.edusoft-lc.com/molconn/manuals/400/chaptwo.html, p.283
-    "gasteiger_charge",
-]
-_PROPS_FUNCS = [
-    get_atomic_number,
-    get_mass,
-    get_van_der_waals_volume,
-    get_sanderson_electronegativity,
-    get_pauling_electronegativity,
-    get_allred_rochow_electronegativity,
-    get_polarizability,
-    get_ionization_potential,
-    get_valence_electrons,
-    get_sigma_electrons,
-    get_intrinsic_state,
-    None,  # Gasteiger charges are calculated separately
-]
-
 FEATURE_NAMES = [
     f"BCUT_{prop}_{kind}_eigval"
-    for prop in _PROPS_NAMES
+    for prop in WEIGHTING_PROPERTY_NAMES
     for kind in ["smallest", "largest"]
 ]
 
 
-def calc(mol: Mol) -> np.ndarray:
+def calc(props: AtomicProperties, n_frags: int) -> np.ndarray:
     """
     BCUT descriptors.
-    """
-    burden_matrix = _get_burden_matrix(mol)
 
-    if len(GetMolFrags(mol)) > 1:
+    Burden eigenvalues: the off-diagonal entries of the Burden matrix encode the
+    bonding pattern, while the diagonal carries an atomic property. The smallest
+    and largest eigenvalues are taken for each property.
+
+    Requires a connected molecule (single fragment).
+    """
+    if n_frags != 1:
         return np.full(len(FEATURE_NAMES), np.nan, dtype=np.float32)
 
-    values = []
-    for name, func in zip(_PROPS_NAMES, _PROPS_FUNCS, strict=True):
-        if name == "gasteiger_charge":
-            props = gasteiger_charges(mol)
-        else:
-            props = atoms_apply_func(func, mol, np.float32)  # type: ignore
+    # the properties differ only along the diagonal, so the matrices are stacked and
+    # decomposed in one call; an undefined property, such as the Gasteiger charge of
+    # a metal, has no matrix of its own and stays NaN
+    prop_vals = props.weighting_properties
+    is_defined = np.isfinite(prop_vals).all(axis=1)
 
-        # some properties are undefined for exotic elements, e.g. Gasteiger charges
-        # for metals; the eigendecomposition cannot run then
-        if np.any(np.isnan(props)):
-            values.extend([np.nan, np.nan])
-            continue
+    matrices = np.repeat(
+        _get_burden_matrix(props)[np.newaxis], is_defined.sum(), axis=0
+    )
+    diagonal = np.arange(props.num_atoms)
+    matrices[:, diagonal, diagonal] = prop_vals[is_defined]
 
-        np.fill_diagonal(burden_matrix, props)
-        eigvals = np.linalg.eigvalsh(burden_matrix)  # ascending order
+    values = np.full((len(prop_vals), 2), np.nan)
+    eigvals = np.linalg.eigvalsh(matrices)  # ascending order
+    values[is_defined] = eigvals[:, [0, -1]]
 
-        smallest = eigvals[0]
-        largest = eigvals[-1]
-
-        values.extend([smallest, largest])
-
-    return np.asarray(values, dtype=np.float32)
+    return values.ravel().astype(np.float32)
 
 
-def _get_burden_matrix(mol: Mol) -> np.ndarray:
-    num_atoms = mol.GetNumAtoms()
+def _get_burden_matrix(props: AtomicProperties) -> np.ndarray:
+    """
+    Burden matrix with an as-yet unset diagonal.
 
-    mat = 0.001 * np.ones((num_atoms, num_atoms))
+    Off-diagonal entries are 0.001 for atom pairs that are not bonded, and the
+    bond order divided by ten for bonded pairs, with 0.01 added when either atom
+    is terminal.
+    """
+    matrix = np.full((props.num_atoms, props.num_atoms), 0.001)
 
-    for bond in mol.GetBonds():
-        a = bond.GetBeginAtom()
-        b = bond.GetEndAtom()
-        i = a.GetIdx()
-        j = b.GetIdx()
+    begins = props.bond_begin_idxs
+    ends = props.bond_end_idxs
+    degrees = props.degrees
+    weights = props.bond_orders / 10.0
+    weights = weights + 0.01 * ((degrees[begins] == 1) | (degrees[ends] == 1))
 
-        w = bond.GetBondTypeAsDouble() / 10.0
+    matrix[begins, ends] = weights
+    matrix[ends, begins] = weights
 
-        if a.GetDegree() == 1 or b.GetDegree() == 1:
-            w += 0.01
-
-        mat[i, j] = w
-        mat[j, i] = w
-
-    return mat
+    return matrix

--- a/tests/fingerprints/_new_mordred/bcut.py
+++ b/tests/fingerprints/_new_mordred/bcut.py
@@ -1,9 +1,10 @@
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
-from rdkit.Chem import MolFromSmiles
+from rdkit.Chem import GetMolFrags, Mol, MolFromSmiles
 
 from skfp.fingerprints._new_mordred.descriptors.bcut import FEATURE_NAMES, calc
+from skfp.fingerprints._new_mordred.utils.atomic_properties import AtomicProperties
 
 """
 This code has been adapted from the BSD-licensed mordred-community library.
@@ -11,6 +12,10 @@ https://github.com/JacksonBurns/mordred-community
 
 See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
 """
+
+
+def _calc(mol: Mol) -> tuple[np.ndarray, list[str]]:
+    return calc(AtomicProperties.from_mol(mol), len(GetMolFrags(mol)))
 
 
 @pytest.mark.parametrize(
@@ -34,7 +39,7 @@ See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license tex
 def test_bcut_mass_values(name, expected_smallest, expected_largest, mordred_test_mols):
     mol = mordred_test_mols[name]
 
-    values = calc(mol)
+    values = _calc(mol)
     values = dict(zip(FEATURE_NAMES, values, strict=True))
     actual_smallest = values["BCUT_mass_smallest_eigval"]
     actual_largest = values["BCUT_mass_largest_eigval"]
@@ -46,5 +51,78 @@ def test_bcut_mass_values(name, expected_smallest, expected_largest, mordred_tes
 
 def test_disconnected_mol_all_nan():
     mol = MolFromSmiles("[Na].[Cl]")
-    values = calc(mol)
+    values = _calc(mol)
     assert_allclose(values, np.nan)
+
+
+# skfp property name -> the abbreviation Mordred uses for the same atomic property
+_MORDRED_PROPERTY_ABBREVIATIONS = {
+    "gasteiger_charge": "c",
+    "valence_electrons": "dv",
+    "sigma_electrons": "d",
+    "intrinsic_state": "s",
+    "atomic_number": "Z",
+    "mass": "m",
+    "van_der_Waals_volume": "v",
+    "Sanderson_electronegativity": "se",
+    "Pauling_electronegativity": "pe",
+    "Allred_Rochow_electronegativity": "are",
+    "polarizability": "p",
+    "ionization_potential": "i",
+}
+
+# Mordred's suffix for the highest and the lowest eigenvalue
+_MORDRED_EIGENVALUE_SUFFIXES = {"largest": "1h", "smallest": "1l"}
+
+
+def _mordred_name(feature_name: str) -> str:
+    """Translate a BCUT feature name into the matching Mordred descriptor name."""
+    prop, kind = (
+        feature_name.removeprefix("BCUT_")
+        .removesuffix("_eigval")
+        .rsplit("_", maxsplit=1)
+    )
+    abbreviation = _MORDRED_PROPERTY_ABBREVIATIONS[prop]
+    return f"BCUT{abbreviation}-{_MORDRED_EIGENVALUE_SUFFIXES[kind]}"
+
+
+@pytest.mark.parametrize(
+    "smiles",
+    [
+        "CC",
+        "CCO",
+        "c1ccccc1",
+        "CC(=O)O",
+        "CC(=O)Oc1ccccc1C(=O)O",
+        "CN1C=NC2=C1C(=O)N(C)C(=O)N2C",
+        "O=S(=O)(O)O",
+        "N[C@@H](CCC(=O)O)C(=O)O",
+    ],
+)
+def test_bcut_matches_mordred_by_feature_name(smiles):
+    """
+    Every BCUT descriptor must match Mordred's value for the same atomic property
+    and eigenvalue, looked up by name so that the result does not depend on the
+    order in which the descriptors happen to be computed.
+    """
+    mordred = pytest.importorskip("mordred")
+
+    mol = MolFromSmiles(smiles)
+    values = _calc(mol)
+    actual = dict(zip(FEATURE_NAMES, values, strict=True))
+
+    calculator = mordred.Calculator(mordred.descriptors.BCUT, ignore_3D=True)
+    expected = {
+        str(descriptor): value
+        for descriptor, value in zip(
+            calculator.descriptors, calculator(mol), strict=True
+        )
+    }
+
+    for feature_name, value in actual.items():
+        assert_allclose(
+            value,
+            float(expected[_mordred_name(feature_name)]),
+            atol=1e-4,
+            err_msg=feature_name,
+        )


### PR DESCRIPTION
The BCUT module was written but never called: the calculator did not list it,
so all 24 BCUT columns came out NaN for every molecule. This wires it in and
rewrites it to work off the shared properties.

- the six weighted Burden matrices are built and decomposed as one stack,
  instead of one matrix and one eigendecomposition per property
- the diagonal weights come from AtomicProperties, so the Gasteiger charges
  and intrinsic states are the ones already computed for other descriptors

This changes the output: the 24 BCUT columns go from NaN to real values,
except for disconnected molecules, which stay NaN by definition (10 of the 300
molecules sampled from MoleculeNet, TDC and MoleculeACE). No other column
changes.

---

Splits up #661 into reviewable pieces. Based on `mordred-opt-11-estate-vsa` - review and merge in order.

<details>
<summary>The stack</summary>

1. #665 - feature names resolved per module
2. #666 - AtomicProperties
3. #667 - hydrogen-explicit matrices derived
4. #668 - spectral attributes over a stack
5. #669 - RingSets
6. #670 - subgraph enumeration (chi, path counts)
7. #671 - detour matrix
8. #672 - ETA descriptors
9. #673 - autocorrelations
10. #674 - Barysz matrices
11. #675 - E-state indices shared with VSA
12. #676 - BCUT (not computed before)  **<- this PR**
13. #677 - walk counts
14. #678 - conformer descriptors
15. #679 - atom, bond and constitutional counts
16. #680 - topological charge and Zagreb
17. #681 - ABC and molecular distance edge
</details>
