### PR TITLE
Mordred: take the walk counts from the adjacency spectrum

### DIFF
--- a/skfp/fingerprints/_new_mordred/calculator.py
+++ b/skfp/fingerprints/_new_mordred/calculator.py
@@ -171,8 +171,7 @@ def compute(mol: Mol, use_3D: bool) -> np.ndarray:
     mol_regular = preprocess_mol(mol)
     distance_matrix_regular = DistanceMatrix.from_mol(mol_regular)
     adjacency_matrix_regular = AdjacencyMatrix(mol_regular)
-    # shared by the adjacency matrix descriptors and, through them, by nothing else
-    # yet; the walk counts join later
+    # shared by the adjacency matrix descriptors and the walk counts
     adjacency_eigendecomposition = np.linalg.eigh(adjacency_matrix_regular.matrix)
 
     # per-atom property arrays and rings, read from the molecule once and shared
@@ -213,7 +212,7 @@ def compute(mol: Mol, use_3D: bool) -> np.ndarray:
     # 2D descriptors
     descriptors_2d: dict[ModuleType, np.ndarray] = {
         abc_index: abc_index.calc(mol_regular, distance_matrix_regular),
-        walk_count: walk_count.calc(mol_regular, adjacency_matrix_regular),
+        walk_count: walk_count.calc(props_regular, adjacency_eigendecomposition),
         path_count: path_count.calc(props_regular, subgraphs_regular),
         adjacency_matrix: adjacency_matrix.calc(
             props_regular,

--- a/skfp/fingerprints/_new_mordred/descriptors/walk_count.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/walk_count.py
@@ -1,7 +1,6 @@
 import numpy as np
-from rdkit.Chem import Mol
 
-from skfp.fingerprints._new_mordred.utils.graph_matrix import AdjacencyMatrix
+from skfp.fingerprints._new_mordred.utils.atomic_properties import AtomicProperties
 
 """
 This code has been adapted from the BSD-licensed mordred-community library.
@@ -39,26 +38,46 @@ FEATURE_NAMES = [
 ]
 
 
-def calc(mol: Mol, adjacency_matrix: AdjacencyMatrix) -> np.ndarray:
-    power = adjacency_matrix.order()
-    molecular_walk_counts: list[float] = []
-    self_returning_walk_counts: list[float] = []
+MAX_ORDER = 10
 
-    for num_order in range(1, 11):
-        if num_order > 1:
-            power = adjacency_matrix.order(num_order)
 
-        if num_order == 1:
-            molecular_walk_counts.append(0.5 * float(power.sum()))
-        else:
-            molecular_walk_counts.append(np.log(float(power.sum()) + 1))
-            self_returning_walk_counts.append(np.log(float(np.trace(power)) + 1))
+def calc(
+    props: AtomicProperties, eigendecomposition: tuple[np.ndarray, np.ndarray]
+) -> np.ndarray:
+    """
+    Walk count descriptors.
+
+    A walk of length k is a sequence of k bonds, and the entries of the k-th power
+    of the adjacency matrix count the walks of that length between two atoms. The
+    whole matrix sums to the molecular walk count, and its trace counts the walks
+    returning to the atom they started from.
+
+    Both sums follow from the eigenvalues of the adjacency matrix, because its
+    powers have the same eigenvectors and the k-th power of an eigenvalue. This
+    is faster than repeated matrix multiplications.
+    """
+    eigvals, eigvecs = eigendecomposition
+
+    # the weight each eigenvalue carries in a sum over the whole matrix
+    weights = eigvecs.sum(axis=0) ** 2
+
+    orders = np.arange(1, MAX_ORDER + 1)[:, np.newaxis]
+    eigval_powers = eigvals**orders
+
+    # walks are counted, so both sums are whole numbers, and rounding to one takes
+    # out whatever the eigenvalue powers left behind of their cancellation
+    walk_counts = np.rint(eigval_powers @ weights)
+    self_returning_counts = np.rint(eigval_powers.sum(axis=1))
+
+    # the first molecular walk count is the bond count, the rest are on a log scale
+    molecular = np.concatenate([[0.5 * walk_counts[0]], np.log(walk_counts[1:] + 1)])
+    self_returning = np.log(self_returning_counts[1:] + 1)
 
     values = [
-        *molecular_walk_counts,
-        mol.GetNumAtoms() + sum(molecular_walk_counts),
-        *self_returning_walk_counts,
-        mol.GetNumAtoms() + sum(self_returning_walk_counts),
+        *molecular,
+        props.num_atoms + molecular.sum(),
+        *self_returning,
+        props.num_atoms + self_returning.sum(),
     ]
 
     return np.asarray(values, dtype=np.float32)


### PR DESCRIPTION
The walk counts multiplied the adjacency matrix by itself ten times, one dense
matrix product per order, to sum and trace each power. The same numbers follow
from the eigendecomposition the calculator already computes for the adjacency
descriptors: the k-th power has the same eigenvectors and the k-th powers of
the eigenvalues, so every order is a weighted sum over the spectrum.

Values are unchanged: identical on 3000 molecules sampled from MoleculeNet,
TDC and MoleculeACE, over all 19 walk count columns.

---

Splits up #661 into reviewable pieces. Based on `mordred-opt-12-bcut` - review and merge in order.

<details>
<summary>The stack</summary>

1. #665 - feature names resolved per module
2. #666 - AtomicProperties
3. #667 - hydrogen-explicit matrices derived
4. #668 - spectral attributes over a stack
5. #669 - RingSets
6. #670 - subgraph enumeration (chi, path counts)
7. #671 - detour matrix
8. #672 - ETA descriptors
9. #673 - autocorrelations
10. #674 - Barysz matrices
11. #675 - E-state indices shared with VSA
12. #676 - BCUT (not computed before)
13. #677 - walk counts  **<- this PR**
14. #678 - conformer descriptors
15. #679 - atom, bond and constitutional counts
16. #680 - topological charge and Zagreb
17. #681 - ABC and molecular distance edge
</details>
