### PR TITLE
Mordred: count atoms, bonds and constitutional sums over arrays

### DIFF
--- a/skfp/fingerprints/_new_mordred/calculator.py
+++ b/skfp/fingerprints/_new_mordred/calculator.py
@@ -202,9 +202,6 @@ def compute(mol: Mol, use_3D: bool) -> np.ndarray:
     # need to copy, since Kekulize modifies in place
     mol_kekulized = preprocess_mol(Mol(mol_regular), kekulize=True, sanitize=False)
     kekulized_bond_types = bonds_apply_func(Bond.GetBondType, mol_kekulized, np.intp)
-    mol_kekulized_hydrogens = preprocess_mol(
-        mol, kekulize=True, explicit_hydrogens=True
-    )
 
     # graph radius and diameter from the hydrogen-suppressed distance matrix
     # E-state indices are shared by EState and VSA descriptors
@@ -234,10 +231,10 @@ def compute(mol: Mol, use_3D: bool) -> np.ndarray:
         rdkit_descriptors: rdkit_descriptors.calc_rdkit_2d(
             mol_regular, props_regular, distance_matrix_regular, estate_indices
         ),
-        atom_count: atom_count.calc(mol_regular),
-        bond_count: bond_count.calc(mol_hydrogens, mol_kekulized_hydrogens),
+        atom_count: atom_count.calc(mol_regular, props_regular),
+        bond_count: bond_count.calc(props_hydrogens, kekulized_bond_types),
         carbon_types: carbon_types.calc(mol_kekulized),
-        constitutional: constitutional.calc(mol_hydrogens),
+        constitutional: constitutional.calc(props_hydrogens),
         rotatable_bond: rotatable_bond.calc(mol_regular),
         log_s: log_s.calc(mol_regular),
         vertex_adjacency_info: vertex_adjacency_info.calc(props_regular),

--- a/skfp/fingerprints/_new_mordred/descriptors/atom_count.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/atom_count.py
@@ -1,8 +1,7 @@
-from collections import Counter
-
 import numpy as np
 from rdkit.Chem import Mol, rdMolDescriptors
 
+from skfp.fingerprints._new_mordred.utils.atomic_properties import AtomicProperties
 from skfp.fingerprints._new_mordred.utils.periodic_table import HALOGEN_ATOMIC_NUMS
 
 """
@@ -34,44 +33,41 @@ FEATURE_NAMES = [
     "nX",
 ]
 
-_ELEMENT_ATOMIC_NUMBERS = [
-    5,  # B
-    6,  # C
-    7,  # N
-    8,  # O
-    16,  # S
-    15,  # P
-    9,  # F
-    17,  # Cl
-    35,  # Br
-    53,  # I
-]
+_ELEMENT_ATOMIC_NUMBERS = np.array(
+    [
+        5,  # B
+        6,  # C
+        7,  # N
+        8,  # O
+        16,  # S
+        15,  # P
+        9,  # F
+        17,  # Cl
+        35,  # Br
+        53,  # I
+    ]
+)
+_HALOGEN_ATOMIC_NUMS = np.array(sorted(HALOGEN_ATOMIC_NUMS))
 
 
-def calc(mol: Mol) -> np.ndarray:
+def calc(mol: Mol, props: AtomicProperties) -> np.ndarray:
     """
     Count atoms by common element and structural category.
     """
-    atoms = mol.GetAtoms()
-    atomic_number_counts = Counter(atom.GetAtomicNum() for atom in atoms)
+    # histogram over atomic numbers, padded so that every element of interest and
+    # every halogen can be indexed without a bounds check
+    max_atomic_num = max(_ELEMENT_ATOMIC_NUMBERS.max(), _HALOGEN_ATOMIC_NUMS.max())
+    counts = np.bincount(props.atomic_nums, minlength=max_atomic_num + 1)
+
     values = [
         rdMolDescriptors.CalcNumAtoms(mol),
         rdMolDescriptors.CalcNumHeavyAtoms(mol),
         rdMolDescriptors.CalcNumSpiroAtoms(mol),
         rdMolDescriptors.CalcNumBridgeheadAtoms(mol),
         rdMolDescriptors.CalcNumHeteroatoms(mol),
-        sum(atom.GetTotalNumHs() for atom in atoms),
+        props.total_num_hs.sum(),
+        *counts[_ELEMENT_ATOMIC_NUMBERS],
+        counts[_HALOGEN_ATOMIC_NUMS].sum(),
     ]
-    values.extend(
-        atomic_number_counts[element_atomic_number]
-        for element_atomic_number in _ELEMENT_ATOMIC_NUMBERS
-    )
-    values.append(
-        sum(
-            atomic_number_count
-            for atomic_number, atomic_number_count in atomic_number_counts.items()
-            if atomic_number in HALOGEN_ATOMIC_NUMS
-        )
-    )
 
     return np.asarray(values, dtype=np.float32)

--- a/skfp/fingerprints/_new_mordred/descriptors/bond_count.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/bond_count.py
@@ -1,6 +1,7 @@
 import numpy as np
-from rdkit.Chem import Mol
 from rdkit.Chem.rdchem import BondType
+
+from skfp.fingerprints._new_mordred.utils.atomic_properties import AtomicProperties
 
 """
 This code has been adapted from the BSD-licensed mordred-community library.
@@ -22,7 +23,9 @@ FEATURE_NAMES = [
 ]
 
 
-def calc(mol_hydrogens: Mol, mol_kekulized_hydrogens: Mol) -> np.ndarray:
+def calc(
+    atomic_props_hydrogens: AtomicProperties, kekulized_bond_types: np.ndarray
+) -> np.ndarray:
     """
     Bond count descriptors.
 
@@ -32,38 +35,33 @@ def calc(mol_hydrogens: Mol, mol_kekulized_hydrogens: Mol) -> np.ndarray:
     Following the original Mordred implementation, nBonds (any) and nBondsS (single)
     are computed on the hydrogen-explicit molecule, while nBondsO (heavy) counts only
     bonds between non-hydrogen atoms. nBondsKS and nBondsKD use the kekulized
-    hydrogen-explicit molecule, where aromatic bonds are expressed as alternating
-    single and double bonds.
+    molecule, where aromatic bonds are expressed as alternating single and double
+    bonds. The hydrogen bonds it would have are all single, so they are counted
+    without building a hydrogen-explicit copy of it.
     """
-    n_bonds = mol_hydrogens.GetNumBonds()
-    n_bonds_o = 0
-    n_bonds_s = 0
-    n_bonds_d = 0
-    n_bonds_t = 0
-    n_bonds_a = 0
-    n_bonds_m = 0
+    bond_types = atomic_props_hydrogens.bond_types
+    is_heavy = ~atomic_props_hydrogens.is_hydrogen
+    is_single = bond_types == BondType.SINGLE
+    is_aromatic = atomic_props_hydrogens.bond_is_aromatic | (
+        bond_types == BondType.AROMATIC
+    )
 
-    for bond in mol_hydrogens.GetBonds():
-        bond_type = bond.GetBondType()
-        is_aromatic = bond.GetIsAromatic() or bond.GetBondType() == BondType.AROMATIC
-        is_heavy = (
-            bond.GetBeginAtom().GetAtomicNum() != 1
-            and bond.GetEndAtom().GetAtomicNum() != 1
-        )
+    n_bonds = atomic_props_hydrogens.num_bonds
+    n_bonds_o = np.count_nonzero(
+        is_heavy[atomic_props_hydrogens.bond_begin_idxs]
+        & is_heavy[atomic_props_hydrogens.bond_end_idxs]
+    )
+    n_bonds_s = np.count_nonzero(is_single)
+    n_bonds_d = np.count_nonzero(bond_types == BondType.DOUBLE)
+    n_bonds_t = np.count_nonzero(bond_types == BondType.TRIPLE)
+    n_bonds_a = np.count_nonzero(is_aromatic)
+    n_bonds_m = np.count_nonzero(is_aromatic | ~is_single)
 
-        n_bonds_o += is_heavy
-        n_bonds_s += bond_type == BondType.SINGLE
-        n_bonds_d += bond_type == BondType.DOUBLE
-        n_bonds_t += bond_type == BondType.TRIPLE
-        n_bonds_a += is_aromatic
-        n_bonds_m += is_aromatic or bond_type != BondType.SINGLE
-
-    n_bonds_ks = 0
-    n_bonds_kd = 0
-    for bond in mol_kekulized_hydrogens.GetBonds():
-        bond_type = bond.GetBondType()
-        n_bonds_ks += bond_type == BondType.SINGLE
-        n_bonds_kd += bond_type == BondType.DOUBLE
+    num_hydrogen_bonds = n_bonds - len(kekulized_bond_types)
+    n_bonds_ks = (
+        np.count_nonzero(kekulized_bond_types == BondType.SINGLE) + num_hydrogen_bonds
+    )
+    n_bonds_kd = np.count_nonzero(kekulized_bond_types == BondType.DOUBLE)
 
     return np.asarray(
         [

--- a/skfp/fingerprints/_new_mordred/descriptors/constitutional.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/constitutional.py
@@ -1,9 +1,8 @@
 import numpy as np
-from rdkit.Chem import Mol
-from rdkit.Chem.rdchem import Atom
 
 from skfp.fingerprints._new_mordred.utils.atomic_properties import (
-    PROPERTY_FUNCS,
+    CARBON_ELEMENT_PROPERTIES,
+    AtomicProperties,
 )
 
 """
@@ -14,6 +13,7 @@ See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license tex
 """
 
 FEATURE_NAMES = [
+    # sums, one per element property, in ELEMENT_PROPERTY_TABLES order
     "SZ",
     "Sm",
     "Sv",
@@ -22,6 +22,7 @@ FEATURE_NAMES = [
     "Sare",
     "Sp",
     "Si",
+    # the same properties again, as means
     "MZ",
     "Mm",
     "Mv",
@@ -32,43 +33,15 @@ FEATURE_NAMES = [
     "Mi",
 ]
 
-_NUM_ELEMENTS = 119
 
-
-def _get_normalized_property_table() -> np.ndarray:
+def calc(props_hydrogens: AtomicProperties) -> np.ndarray:
     """
-    Precompute each atomic property divided by its value for carbon.
+    Constitutional descriptors: the sum (``S*``) and mean (``M*``) over the atoms of
+    every element property, each normalized by the property's value for carbon.
+
+    Hydrogens count as atoms here, so this works on the hydrogen-explicit molecule.
+    Normalizing the sums rather than the individual atoms divides eight times instead
+    of once per atom, which the sum of a quotient permits.
     """
-    atoms = tuple(Atom(atomic_num) for atomic_num in range(_NUM_ELEMENTS))
-    property_values = np.asarray(
-        [
-            [property_func(atom) for atom in atoms]
-            for property_func in PROPERTY_FUNCS.values()
-        ],
-        dtype=np.float64,
-    )
-    # Keep shape as (num_properties, 1) so broadcasting divides each row by carbon
-    # while preserving the atom axis.
-    carbon_values = property_values[:, 6].reshape(-1, 1)
-    return property_values / carbon_values
-
-
-_CARBON_NORMALIZED_PROPERTIES = _get_normalized_property_table()
-
-
-def calc(mol_hydrogens: Mol) -> np.ndarray:
-    """
-    Compute the Mordred constitutional descriptors.
-
-    For each atomic property, the property values of all atoms, including explicit
-    hydrogens, are normalized by the corresponding value for carbon. The `S*`
-    descriptors are their sums and the `M*` descriptors are their means.
-    """
-    atomic_numbers = np.fromiter(
-        (atom.GetAtomicNum() for atom in mol_hydrogens.GetAtoms()),
-        dtype=np.intp,
-        count=mol_hydrogens.GetNumAtoms(),
-    )
-    sums = _CARBON_NORMALIZED_PROPERTIES[:, atomic_numbers].sum(axis=1)
-    means = sums / atomic_numbers.size
-    return np.concatenate((sums, means)).astype(np.float32)
+    sums = props_hydrogens.element_properties.sum(axis=1) / CARBON_ELEMENT_PROPERTIES
+    return np.concatenate((sums, sums / props_hydrogens.num_atoms)).astype(np.float32)

--- a/skfp/fingerprints/_new_mordred/utils/atomic_properties.py
+++ b/skfp/fingerprints/_new_mordred/utils/atomic_properties.py
@@ -1,5 +1,3 @@
-from collections.abc import Callable
-
 import numpy as np
 from rdkit import Chem
 from rdkit.Chem.rdchem import Atom, Bond, BondType, Mol
@@ -387,17 +385,3 @@ class AtomicProperties:
                 (2.0 / periods) ** 2 * self.valence_electrons + 1
             ) / self.sigma_electrons
         return np.where(self.sigma_electrons == 0, np.nan, values)
-
-
-# kept until autocorrelation, barysz_matrix and constitutional move to
-# AtomicProperties; they still read one property of one atom at a time
-PROPERTY_FUNCS: dict[str, Callable[[Atom], float]] = {
-    "atomic_number": get_atomic_number,
-    "mass": get_mass,
-    "van_der_Waals_volume": get_van_der_waals_volume,
-    "Sanderson_electronegativity": get_sanderson_electronegativity,
-    "Pauling_electronegativity": get_pauling_electronegativity,
-    "Allred_Rochow_electronegativity": get_allred_rochow_electronegativity,
-    "polarizability": get_polarizability,
-    "ionization_potential": get_ionization_potential,
-}

--- a/tests/fingerprints/_new_mordred/atom_count.py
+++ b/tests/fingerprints/_new_mordred/atom_count.py
@@ -4,6 +4,7 @@ from numpy.testing import assert_allclose
 from rdkit.Chem import MolFromSmiles
 
 from skfp.fingerprints._new_mordred.descriptors import atom_count
+from skfp.fingerprints._new_mordred.utils.atomic_properties import AtomicProperties
 
 FEATURE_NAMES = [
     "nAtom",
@@ -40,5 +41,5 @@ FEATURE_NAMES = [
 def test_atom_count_values(smiles, expected):
     mol = MolFromSmiles(smiles)
 
-    values = atom_count.calc(mol)
+    values = atom_count.calc(mol, AtomicProperties.from_mol(mol))
     assert_allclose(values, np.asarray(expected, dtype=np.float32))

--- a/tests/fingerprints/_new_mordred/bond_count.py
+++ b/tests/fingerprints/_new_mordred/bond_count.py
@@ -1,8 +1,11 @@
 import numpy as np
 import pytest
 from rdkit.Chem import AddHs, Kekulize, MolFromSmiles, RWMol
+from rdkit.Chem.rdchem import Bond
 
 from skfp.fingerprints._new_mordred.descriptors.bond_count import FEATURE_NAMES, calc
+from skfp.fingerprints._new_mordred.utils.atomic_properties import AtomicProperties
+from skfp.fingerprints._new_mordred.utils.mol_preprocess import bonds_apply_func
 
 """
 This code has been adapted from the BSD-licensed mordred-community library.
@@ -16,9 +19,10 @@ See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license tex
 
 def _calc(smiles: str) -> np.ndarray:
     mol = AddHs(MolFromSmiles(smiles))
-    mol_kek = RWMol(AddHs(MolFromSmiles(smiles)))
+    mol_kek = RWMol(MolFromSmiles(smiles))
     Kekulize(mol_kek)
-    values = calc(mol, mol_kek)
+    kekulized_bond_types = bonds_apply_func(Bond.GetBondType, mol_kek, np.intp)
+    values = calc(AtomicProperties.from_mol(mol), kekulized_bond_types)
     return values
 
 

--- a/tests/fingerprints/_new_mordred/constitutional.py
+++ b/tests/fingerprints/_new_mordred/constitutional.py
@@ -8,6 +8,7 @@ from skfp.fingerprints._new_mordred.descriptors.constitutional import (
     FEATURE_NAMES,
     calc,
 )
+from skfp.fingerprints._new_mordred.utils.atomic_properties import AtomicProperties
 from skfp.fingerprints._new_mordred.utils.mol_preprocess import preprocess_mol
 
 """
@@ -32,7 +33,7 @@ def computed_values(mordred_test_mols):
     computed = {}
     for name in _MOLECULES:
         mol = preprocess_mol(mordred_test_mols[name], explicit_hydrogens=True)
-        values = calc(mol)
+        values = calc(AtomicProperties.from_mol(mol))
         computed[name] = dict(zip(FEATURE_NAMES, values, strict=True))
     return computed
 


### PR DESCRIPTION
Three descriptors that walked the molecule to count things now read the
shared property arrays:

- atom_count histograms the atomic numbers with bincount, instead of building
  a Counter and looking up each element of interest
- bond_count masks the bond type array, and takes the kekulized bond types
  that the calculator already extracts for the ETA descriptors, which removes
  the last use of the kekulized hydrogen-explicit molecule - one preprocess_mol
  call per molecule
- constitutional sums the per-atom property arrays directly

PROPERTY_FUNCS, kept while these descriptors still read one property of one
atom at a time, has no consumers left and is removed.

Output is unchanged: identical values on 300 molecules sampled from
MoleculeNet, TDC and MoleculeACE.

---

Splits up #661 into reviewable pieces. Based on `mordred-opt-14-3d` - review and merge in order.

<details>
<summary>The stack</summary>

1. #665 - feature names resolved per module
2. #666 - AtomicProperties
3. #667 - hydrogen-explicit matrices derived
4. #668 - spectral attributes over a stack
5. #669 - RingSets
6. #670 - subgraph enumeration (chi, path counts)
7. #671 - detour matrix
8. #672 - ETA descriptors
9. #673 - autocorrelations
10. #674 - Barysz matrices
11. #675 - E-state indices shared with VSA
12. #676 - BCUT (not computed before)
13. #677 - walk counts
14. #678 - conformer descriptors
15. #679 - atom, bond and constitutional counts  **<- this PR**
16. #680 - topological charge and Zagreb
17. #681 - ABC and molecular distance edge
</details>
