### PR TITLE
Mordred: accumulate the topological charge and Zagreb sums with bincount

### DIFF
--- a/skfp/fingerprints/_new_mordred/calculator.py
+++ b/skfp/fingerprints/_new_mordred/calculator.py
@@ -222,7 +222,7 @@ def compute(mol: Mol, use_3D: bool) -> np.ndarray:
             adjacency_eigendecomposition,
         ),
         wiener_index: wiener_index.calc(mol_regular, distance_matrix_regular),
-        zagreb_index: zagreb_index.calc(mol_regular, adjacency_matrix_regular),
+        zagreb_index: zagreb_index.calc(props_regular, adjacency_matrix_regular),
         acid_base: acid_base.calc(mol_regular),
         autocorrelation: autocorrelation.calc(
             props_hydrogens, distance_matrix_hydrogens

--- a/skfp/fingerprints/_new_mordred/descriptors/topological_charge.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/topological_charge.py
@@ -44,21 +44,22 @@ def calc(
     )
 
     # keep only lower-triangle atom pairs (strictly below the diagonal), so each
-    # unordered pair is counted once; mark everything else as unreachable so it
-    # is dropped when filtering by topological distance
+    # unordered pair is counted once; everything else is mapped to order 0, which
+    # is dropped below
     dist = distance_matrix_regular.matrix * np.tri(*charge_terms.shape)
-    dist[dist == 0] = np.inf
+    orders = np.where(dist <= _MAX_ORDER, dist, 0).astype(np.intp)
 
-    raw = np.zeros(_MAX_ORDER, dtype=np.float32)
-    mean = np.zeros(_MAX_ORDER, dtype=np.float32)
-    for order in range(1, _MAX_ORDER + 1):
-        mask = dist == order
-        count = np.count_nonzero(mask)
-        raw_sum = np.abs(charge_terms[mask]).sum()
+    # accumulate all orders
+    counts = np.bincount(orders.ravel(), minlength=_MAX_ORDER + 1)[1:]
+    raw = np.bincount(
+        orders.ravel(), weights=np.abs(charge_terms).ravel(), minlength=_MAX_ORDER + 1
+    )
 
-        raw[order - 1] = raw_sum
-        mean[order - 1] = raw_sum / count if count else 0.0
+    # drop the unused order 0 bucket
+    raw = raw[1:]
 
+    mean = np.divide(raw, counts, out=np.zeros_like(raw), where=counts != 0)
+    mean = mean.astype(np.float32)
     global_charge = mean.sum()
 
     values = np.concatenate([raw, mean, [global_charge]], dtype=np.float32)

--- a/skfp/fingerprints/_new_mordred/descriptors/zagreb_index.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/zagreb_index.py
@@ -1,7 +1,6 @@
 import numpy as np
-from rdkit.Chem import Mol
 
-from skfp.descriptors import zagreb_index_m1, zagreb_index_m2
+from skfp.fingerprints._new_mordred.utils.atomic_properties import AtomicProperties
 from skfp.fingerprints._new_mordred.utils.graph_matrix import AdjacencyMatrix
 
 """
@@ -14,22 +13,26 @@ See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license tex
 FEATURE_NAMES = ["Zagreb1", "Zagreb2", "mZagreb1", "mZagreb2"]
 
 
-def calc(mol_regular: Mol, adjacency_matrix_regular: AdjacencyMatrix) -> np.ndarray:
-    values = np.array(
-        [
-            zagreb_index_m1(mol_regular, degree_vector=adjacency_matrix_regular.degree),
-            zagreb_index_m2(mol_regular, degree_vector=adjacency_matrix_regular.degree),
-            zagreb_index_m1(
-                mol_regular,
-                degree_vector=adjacency_matrix_regular.degree,
-                modified=True,
-            ),
-            zagreb_index_m2(
-                mol_regular,
-                degree_vector=adjacency_matrix_regular.degree,
-                modified=True,
-            ),
-        ],
-        dtype=np.float32,
-    )
-    return values
+def calc(
+    props: AtomicProperties, adjacency_matrix_regular: AdjacencyMatrix
+) -> np.ndarray:
+    """
+    Zagreb indices.
+
+    The first index sums the squared degree of every atom, the second the product of
+    the degrees at both ends of every bond. Their modified variants sum the same
+    quantities inverted, which is undefined when something has no degree to invert.
+
+    Computes the same values as :func:`skfp.descriptors.zagreb_index_m1` and
+    :func:`skfp.descriptors.zagreb_index_m2`, which sum over the bonds in Python.
+    """
+    degrees = adjacency_matrix_regular.degree
+    bond_degrees = degrees[props.bond_begin_idxs] * degrees[props.bond_end_idxs]
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        zagreb_1 = (degrees**2).sum()
+        zagreb_2 = bond_degrees.sum()
+        modified_1 = np.nan if (degrees == 0).any() else (degrees**-2.0).sum()
+        modified_2 = np.nan if (bond_degrees == 0).any() else (1.0 / bond_degrees).sum()
+
+    return np.asarray([zagreb_1, zagreb_2, modified_1, modified_2], dtype=np.float32)

--- a/tests/fingerprints/_new_mordred/zagreb_index.py
+++ b/tests/fingerprints/_new_mordred/zagreb_index.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_allclose
 from skfp.fingerprints._new_mordred.descriptors.zagreb_index import (
     calc,
 )
+from skfp.fingerprints._new_mordred.utils.atomic_properties import AtomicProperties
 from skfp.fingerprints._new_mordred.utils.graph_matrix import AdjacencyMatrix
 from skfp.fingerprints._new_mordred.utils.mol_preprocess import preprocess_mol
 
@@ -38,7 +39,7 @@ def test_zagreb1_values(name, expected_zagreb1, mordred_test_mols):
     mol_regular = preprocess_mol(mordred_test_mols[name])
     adjacency_matrix_regular = AdjacencyMatrix(mol_regular)
 
-    values = calc(mol_regular, adjacency_matrix_regular)
+    values = calc(AtomicProperties.from_mol(mol_regular), adjacency_matrix_regular)
     assert_allclose(values[0], np.float32(expected_zagreb1), rtol=1e-6)
 
 
@@ -49,5 +50,5 @@ def test_zagreb_all_features(mordred_test_mols):
     mol_regular = preprocess_mol(mordred_test_mols["MethylCyclopropane"])
     adjacency_matrix_regular = AdjacencyMatrix(mol_regular)
 
-    values = calc(mol_regular, adjacency_matrix_regular)
+    values = calc(AtomicProperties.from_mol(mol_regular), adjacency_matrix_regular)
     assert_allclose(values, np.asarray(expected, dtype=np.float32), atol=1e-2)


### PR DESCRIPTION
- topological_charge bucketed the atom pairs by topological distance with one
  boolean mask per order, seven passes over the whole matrix; the orders are
  now accumulated in a single bincount over the distances, with the pairs it
  does not want mapped to a bucket that is dropped
- zagreb_index reads the degrees and the valence degrees from the shared
  properties, instead of summing over atoms and bonds in Python

Output is unchanged: identical values on 300 molecules sampled from
MoleculeNet, TDC and MoleculeACE.

---

Splits up #661 into reviewable pieces. Based on `mordred-opt-15-counts` - review and merge in order.

<details>
<summary>The stack</summary>

1. #665 - feature names resolved per module
2. #666 - AtomicProperties
3. #667 - hydrogen-explicit matrices derived
4. #668 - spectral attributes over a stack
5. #669 - RingSets
6. #670 - subgraph enumeration (chi, path counts)
7. #671 - detour matrix
8. #672 - ETA descriptors
9. #673 - autocorrelations
10. #674 - Barysz matrices
11. #675 - E-state indices shared with VSA
12. #676 - BCUT (not computed before)
13. #677 - walk counts
14. #678 - conformer descriptors
15. #679 - atom, bond and constitutional counts
16. #680 - topological charge and Zagreb  **<- this PR**
17. #681 - ABC and molecular distance edge
</details>
