### PR TITLE
Mordred: vectorize the ABC and molecular distance edge descriptors

### DIFF
--- a/skfp/fingerprints/_new_mordred/calculator.py
+++ b/skfp/fingerprints/_new_mordred/calculator.py
@@ -203,16 +203,16 @@ def compute(mol: Mol, use_3D: bool) -> np.ndarray:
     mol_kekulized = preprocess_mol(Mol(mol_regular), kekulize=True, sanitize=False)
     kekulized_bond_types = bonds_apply_func(Bond.GetBondType, mol_kekulized, np.intp)
 
-    # graph radius and diameter from the hydrogen-suppressed distance matrix
     # E-state indices are shared by EState and VSA descriptors
     estate_indices = estate.calc_indices(props_regular, distance_matrix_regular)
 
+    # graph radius and diameter from the hydrogen-suppressed distance matrix
     graph_radius = distance_matrix_regular.radius
     graph_diameter = distance_matrix_regular.diameter
 
     # 2D descriptors
     descriptors_2d: dict[ModuleType, np.ndarray] = {
-        abc_index: abc_index.calc(mol_regular, distance_matrix_regular),
+        abc_index: abc_index.calc(props_regular, distance_matrix_regular),
         walk_count: walk_count.calc(props_regular, adjacency_eigendecomposition),
         path_count: path_count.calc(props_regular, subgraphs_regular),
         adjacency_matrix: adjacency_matrix.calc(
@@ -273,7 +273,7 @@ def compute(mol: Mol, use_3D: bool) -> np.ndarray:
             props_regular, distance_matrix_regular, rings_regular, n_frags
         ),
         molecular_distance_edge: molecular_distance_edge.calc(
-            mol_regular, adjacency_matrix_regular, distance_matrix_regular
+            props_regular, adjacency_matrix_regular, distance_matrix_regular
         ),
         molecular_id: molecular_id.calc(props_regular, n_frags),
     }

--- a/skfp/fingerprints/_new_mordred/descriptors/abc_index.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/abc_index.py
@@ -1,6 +1,6 @@
 import numpy as np
-from rdkit.Chem import Mol
 
+from skfp.fingerprints._new_mordred.utils.atomic_properties import AtomicProperties
 from skfp.fingerprints._new_mordred.utils.graph_matrix import DistanceMatrix
 
 """
@@ -13,46 +13,9 @@ See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license tex
 FEATURE_NAMES = ["ABC", "ABCGG"]
 
 
-def _calc_abc_index(mol: Mol) -> float:
-    """
-    Atom-bond connectivity (ABC) index descriptor.
-
-    Based on Das, K. C., Gutman, I., & Furtula, B. (2012). On atom-bond
-    connectivity index. Filomat, 26(4), 733-738.
-    https://doi.org/10.2298/FIL1204733D
-    """
-    total = 0.0
-    for bond in mol.GetBonds():
-        du = bond.GetBeginAtom().GetDegree()
-        dv = bond.GetEndAtom().GetDegree()
-        total += np.sqrt((du + dv - 2.0) / (du * dv))
-    return total
-
-
-def _calc_abcgg_index(mol: Mol, distance_matrix_regular: DistanceMatrix) -> float:
-    """
-    Graovac-Ghorbani atom-bond connectivity index descriptor.
-
-    Based on Furtula, B. (2016). Atom-bond connectivity index versus
-    Graovac-Ghorbani analog. MATCH Communications in Mathematical and in
-    Computer Chemistry, 75(1), 233-242.
-    http://match.pmf.kg.ac.rs/electronic_versions/Match75/n1/match75n1_233-242.pdf
-    """
-    D = distance_matrix_regular.matrix
-
-    total = 0.0
-    for bond in mol.GetBonds():
-        u = bond.GetBeginAtomIdx()
-        v = bond.GetEndAtomIdx()
-
-        nu = np.sum(D[u, :] < D[v, :])
-        nv = np.sum(D[v, :] < D[u, :])
-
-        total += np.sqrt((nu + nv - 2.0) / (nu * nv))
-    return total
-
-
-def calc(mol_regular: Mol, distance_matrix_regular: DistanceMatrix) -> np.ndarray:
+def calc(
+    atomic_props_regular: AtomicProperties, distance_matrix_regular: DistanceMatrix
+) -> np.ndarray:
     """
     ABC index descriptor, combining the classical ABC index and its
     Graovac-Ghorbani analog.
@@ -64,9 +27,47 @@ def calc(mol_regular: Mol, distance_matrix_regular: DistanceMatrix) -> np.ndarra
     """
     values = np.array(
         [
-            _calc_abc_index(mol_regular),
-            _calc_abcgg_index(mol_regular, distance_matrix_regular),
+            _calc_abc_index(atomic_props_regular),
+            _calc_abcgg_index(atomic_props_regular, distance_matrix_regular),
         ],
         dtype=np.float32,
     )
     return values
+
+
+def _calc_abc_index(props: AtomicProperties) -> float:
+    """
+    Atom-bond connectivity (ABC) index descriptor.
+
+    Based on Das, K. C., Gutman, I., & Furtula, B. (2012). On atom-bond
+    connectivity index. Filomat, 26(4), 733-738.
+    https://doi.org/10.2298/FIL1204733D
+    """
+    degrees = props.degrees
+    du = degrees[props.bond_begin_idxs]
+    dv = degrees[props.bond_end_idxs]
+    return float(np.sqrt((du + dv - 2.0) / (du * dv)).sum())
+
+
+def _calc_abcgg_index(
+    props: AtomicProperties, distance_matrix_regular: DistanceMatrix
+) -> float:
+    """
+    Graovac-Ghorbani atom-bond connectivity index descriptor.
+
+    Based on Furtula, B. (2016). Atom-bond connectivity index versus
+    Graovac-Ghorbani analog. MATCH Communications in Mathematical and in
+    Computer Chemistry, 75(1), 233-242.
+    http://match.pmf.kg.ac.rs/electronic_versions/Match75/n1/match75n1_233-242.pdf
+    """
+    D = distance_matrix_regular.matrix
+
+    # rows of the distance matrix for the two ends of every bond, at once
+    dist_u = D[props.bond_begin_idxs]
+    dist_v = D[props.bond_end_idxs]
+
+    # nu/nv: atoms closer to one end of the bond than to the other
+    nu = (dist_u < dist_v).sum(axis=1)
+    nv = (dist_v < dist_u).sum(axis=1)
+
+    return float(np.sqrt((nu + nv - 2.0) / (nu * nv)).sum())

--- a/skfp/fingerprints/_new_mordred/descriptors/molecular_distance_edge.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/molecular_distance_edge.py
@@ -1,6 +1,6 @@
 import numpy as np
-from rdkit.Chem import Mol
 
+from skfp.fingerprints._new_mordred.utils.atomic_properties import AtomicProperties
 from skfp.fingerprints._new_mordred.utils.graph_matrix import (
     AdjacencyMatrix,
     DistanceMatrix,
@@ -53,18 +53,15 @@ for _idx, (_z, _v1, _v2) in enumerate(_BUCKETS):
 
 @np.errstate(divide="ignore", invalid="ignore")
 def calc(
-    mol_regular: Mol,
+    atomic_props_regular: AtomicProperties,
     adjacency_matrix_regular: AdjacencyMatrix,
     distance_matrix_regular: DistanceMatrix,
 ) -> np.ndarray:
-    num_atoms = mol_regular.GetNumAtoms()
-    adj = adjacency_matrix_regular.matrix
+    num_atoms = atomic_props_regular.num_atoms
     dists = distance_matrix_regular.matrix
 
-    atomic_nums = np.fromiter(
-        (atom.GetAtomicNum() for atom in mol_regular.GetAtoms()), int, num_atoms
-    )
-    valences = adj.sum(axis=0).astype(int)
+    atomic_nums = atomic_props_regular.atomic_nums
+    valences = adjacency_matrix_regular.degree.astype(int)
 
     # enumerate atom pairs (unordered) and bucket by valence
     i, j = np.triu_indices(num_atoms, k=1)

--- a/tests/fingerprints/_new_mordred/abc_index.py
+++ b/tests/fingerprints/_new_mordred/abc_index.py
@@ -6,6 +6,7 @@ from skfp.fingerprints._new_mordred.descriptors.abc_index import (
     _calc_abc_index,
     _calc_abcgg_index,
 )
+from skfp.fingerprints._new_mordred.utils.atomic_properties import AtomicProperties
 from skfp.fingerprints._new_mordred.utils.graph_matrix import DistanceMatrix
 
 """
@@ -30,5 +31,8 @@ def test_abc_index_reference_values(smiles, expected_abc, expected_abcgg):
     mol = MolFromSmiles(smiles)
     distance_matrix = DistanceMatrix.from_mol(mol)
 
-    assert_allclose(_calc_abc_index(mol), expected_abc, atol=1e-2)
-    assert_allclose(_calc_abcgg_index(mol, distance_matrix), expected_abcgg, atol=1e-2)
+    props = AtomicProperties.from_mol(mol)
+    assert_allclose(_calc_abc_index(props), expected_abc, atol=1e-2)
+    assert_allclose(
+        _calc_abcgg_index(props, distance_matrix), expected_abcgg, atol=1e-2
+    )

--- a/tests/fingerprints/_new_mordred/molecular_distance_edge.py
+++ b/tests/fingerprints/_new_mordred/molecular_distance_edge.py
@@ -9,6 +9,7 @@ from skfp.fingerprints._new_mordred.descriptors.molecular_distance_edge import (
     FEATURE_NAMES,
     calc,
 )
+from skfp.fingerprints._new_mordred.utils.atomic_properties import AtomicProperties
 from skfp.fingerprints._new_mordred.utils.graph_matrix import (
     AdjacencyMatrix,
     DistanceMatrix,
@@ -41,7 +42,7 @@ def computed_values(mordred_test_mols):
     for name in _REFERENCE:
         mol_regular = preprocess_mol(mordred_test_mols[name])
         values = calc(
-            mol_regular,
+            AtomicProperties.from_mol(mol_regular),
             AdjacencyMatrix(mol_regular),
             DistanceMatrix.from_mol(mol_regular),
         )
@@ -63,7 +64,9 @@ def test_molecular_distance_edge_reference_values(
 def test_molecular_distance_edge_output_shape(mordred_test_mols):
     mol_regular = preprocess_mol(mordred_test_mols["Caffeine"])
     values = calc(
-        mol_regular, AdjacencyMatrix(mol_regular), DistanceMatrix.from_mol(mol_regular)
+        AtomicProperties.from_mol(mol_regular),
+        AdjacencyMatrix(mol_regular),
+        DistanceMatrix.from_mol(mol_regular),
     )
 
     assert isinstance(values, np.ndarray)
@@ -76,7 +79,9 @@ def test_molecular_distance_edge_no_matching_atoms(mordred_test_mols):
     # while carbon buckets that occur are finite
     mol_regular = preprocess_mol(mordred_test_mols["Hexane"])
     values = calc(
-        mol_regular, AdjacencyMatrix(mol_regular), DistanceMatrix.from_mol(mol_regular)
+        AtomicProperties.from_mol(mol_regular),
+        AdjacencyMatrix(mol_regular),
+        DistanceMatrix.from_mol(mol_regular),
     )
     result = dict(zip(FEATURE_NAMES, values, strict=True))
 


### PR DESCRIPTION


---

Splits up #661 into reviewable pieces. Based on `mordred-opt-16-topological` - review and merge in order.

<details>
<summary>The stack</summary>

1. #665 - feature names resolved per module
2. #666 - AtomicProperties
3. #667 - hydrogen-explicit matrices derived
4. #668 - spectral attributes over a stack
5. #669 - RingSets
6. #670 - subgraph enumeration (chi, path counts)
7. #671 - detour matrix
8. #672 - ETA descriptors
9. #673 - autocorrelations
10. #674 - Barysz matrices
11. #675 - E-state indices shared with VSA
12. #676 - BCUT (not computed before)
13. #677 - walk counts
14. #678 - conformer descriptors
15. #679 - atom, bond and constitutional counts
16. #680 - topological charge and Zagreb
17. #681 - ABC and molecular distance edge  **<- this PR**
</details>
