### PR TITLE
Mordred: add the molecular ID descriptors

### DIFF
--- a/skfp/fingerprints/_new_mordred/calculator.py
+++ b/skfp/fingerprints/_new_mordred/calculator.py
@@ -26,6 +26,7 @@ from skfp.fingerprints._new_mordred.descriptors import (
     geometric_index,
     gravitational_index,
     molecular_distance_edge,
+    molecular_id,
     morse,
     path_count,
     polarizability,
@@ -80,6 +81,7 @@ MODULES_2D: list[ModuleType] = [
     extended_topochemical_atom,
     fragment_complexity,
     molecular_distance_edge,
+    molecular_id,
     path_count,
     polarizability,
     rdkit_descriptors,  # both 2D and 3D
@@ -247,6 +249,7 @@ def compute(mol: Mol, use_3D: bool) -> np.ndarray:
         molecular_distance_edge: molecular_distance_edge.calc(
             mol_regular, adjacency_matrix_regular, distance_matrix_regular
         ),
+        molecular_id: molecular_id.calc(props_regular, n_frags),
     }
 
     for module, values in descriptors_2d.items():

--- a/skfp/fingerprints/_new_mordred/descriptors/molecular_id.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/molecular_id.py
@@ -38,7 +38,13 @@ _HYDROGEN_ATOMIC_NUM = 1
 _CARBON_ATOMIC_NUM = 6
 _NITROGEN_ATOMIC_NUM = 7
 _OXYGEN_ATOMIC_NUM = 8
-_HALOGEN_ATOMIC_NUMS = np.asarray(sorted(HALOGEN_ATOMIC_NUMS), dtype=np.intp)
+
+# one flag per atomic number, indexed by the atomic number itself. Selecting the
+# halogens this way is a plain gather, where np.isin spends more time sorting its
+# few needles than the whole lookup takes.
+_NUM_ATOMIC_NUMBERS = 119  # atomic numbers 0 to 118, as RDKit reports them
+_IS_HALOGEN = np.zeros(_NUM_ATOMIC_NUMBERS, dtype=bool)
+_IS_HALOGEN[sorted(HALOGEN_ATOMIC_NUMS)] = True
 
 
 def calc(props_regular: AtomicProperties, n_frags: int) -> np.ndarray:
@@ -62,18 +68,17 @@ def calc(props_regular: AtomicProperties, n_frags: int) -> np.ndarray:
     is_hetero = (atomic_nums != _HYDROGEN_ATOMIC_NUM) & (
         atomic_nums != _CARBON_ATOMIC_NUM
     )
-    selections = [
-        np.ones(props_regular.num_atoms, dtype=bool),
-        is_hetero,
-        atomic_nums == _CARBON_ATOMIC_NUM,
-        atomic_nums == _NITROGEN_ATOMIC_NUM,
-        atomic_nums == _OXYGEN_ATOMIC_NUM,
-        np.isin(atomic_nums, _HALOGEN_ATOMIC_NUMS),
+    molecular_ids = [
+        atom_ids.sum(),  # every atom, so no selection to build
+        atom_ids[is_hetero].sum(),
+        atom_ids[atomic_nums == _CARBON_ATOMIC_NUM].sum(),
+        atom_ids[atomic_nums == _NITROGEN_ATOMIC_NUM].sum(),
+        atom_ids[atomic_nums == _OXYGEN_ATOMIC_NUM].sum(),
+        atom_ids[_IS_HALOGEN[atomic_nums]].sum(),
     ]
 
     values = []
-    for selection in selections:
-        molecular_id = atom_ids[selection].sum()
+    for molecular_id in molecular_ids:
         # averaged over every atom of the molecule, not over the selected ones
         values += [molecular_id, molecular_id / props_regular.num_atoms]
 

--- a/skfp/fingerprints/_new_mordred/descriptors/molecular_id.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/molecular_id.py
@@ -90,6 +90,9 @@ def _atom_ids(props: AtomicProperties) -> np.ndarray:
     Atomic ID of every atom: one plus half the sum, over all simple paths
     starting at that atom, of the inverse square root of the product of the
     path's edge weights.
+
+    This is by far the most expensive part of the descriptor; see
+    :func:`_sum_over_paths` for why enumerating those paths is exponential.
     """
     adjacency = _weighted_adjacency(props)
     num_atoms = props.num_atoms
@@ -137,8 +140,18 @@ def _sum_over_paths(
     Sum of the inverse square root of the edge weight product over every simple
     path that extends the one ending at ``atom``.
 
-    ``visited`` marks the atoms already on the path and is restored on the way
-    out, so the same buffer serves every starting atom.
+    This is a backtracking search rather than a plain depth-first traversal:
+    ``visited`` marks the atoms on the *current path*, not the atoms already
+    seen, and the mark is undone on the way out. An atom is therefore re-entered
+    once per route that reaches it, and the recursion has one call per simple
+    path instead of one per atom. The cost is exponential in the number of rings
+    -- a plain traversal of pentacene makes 22 calls from a given atom, this one
+    makes 359 -- and there is no way around it: the sum needs one term per path,
+    and the paths have to be simple, so no per-atom bookkeeping can stand in for
+    walking them. It does degenerate to a plain traversal for acyclic molecules,
+    where only one route reaches each atom.
+
+    Restoring the marks also lets one buffer serve every starting atom.
     """
     visited[atom] = 1
     total = 0.0

--- a/skfp/fingerprints/_new_mordred/descriptors/molecular_id.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/molecular_id.py
@@ -100,10 +100,6 @@ def _weighted_adjacency(props: AtomicProperties) -> list[list[tuple[int, int]]]:
     """
     Neighbors of every atom paired with their bond weight, the product of the
     degrees of the two bonded atoms.
-
-    Kept as nested Python lists of plain ints rather than NumPy arrays: the path
-    search below reads them one edge at a time, where boxing NumPy scalars costs
-    far more than the lookup itself.
     """
     degrees = props.degrees
     begin_idxs = props.bond_begin_idxs.tolist()

--- a/skfp/fingerprints/_new_mordred/descriptors/molecular_id.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/molecular_id.py
@@ -1,0 +1,152 @@
+from math import sqrt
+
+import numpy as np
+
+from skfp.fingerprints._new_mordred.utils.atomic_properties import AtomicProperties
+from skfp.fingerprints._new_mordred.utils.periodic_table import HALOGEN_ATOMIC_NUMS
+
+"""
+Molecular ID descriptors.
+
+This code has been adapted from the BSD-licensed mordred-community library.
+https://github.com/JacksonBurns/mordred-community
+
+See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
+"""
+
+FEATURE_NAMES = [
+    "MID",
+    "AMID",
+    "MID_h",
+    "AMID_h",
+    "MID_C",
+    "AMID_C",
+    "MID_N",
+    "AMID_N",
+    "MID_O",
+    "AMID_O",
+    "MID_X",
+    "AMID_X",
+]
+
+# a path stops being extended once the product of its edge weights reaches this
+# limit, as anything longer would contribute less than Mordred's 1e-10 epsilon;
+# Mordred spells the same number as int(1 / eps ** 2)
+_WEIGHT_PRODUCT_LIMIT = 10**20
+
+_HYDROGEN_ATOMIC_NUM = 1
+_CARBON_ATOMIC_NUM = 6
+_NITROGEN_ATOMIC_NUM = 7
+_OXYGEN_ATOMIC_NUM = 8
+_HALOGEN_ATOMIC_NUMS = np.asarray(sorted(HALOGEN_ATOMIC_NUMS), dtype=np.intp)
+
+
+def calc(props_regular: AtomicProperties, n_frags: int) -> np.ndarray:
+    """
+    Molecular ID descriptors, sums of atomic IDs over a selected set of atoms.
+
+    The features come in pairs: a sum over the selected atoms and that same sum
+    averaged over the molecule. Selections are all atoms (``MID``), heteroatoms
+    (``MID_h``), carbons, nitrogens, oxygens and halogens (``MID_X``).
+
+    Atomic IDs are undefined for disconnected molecules, so NaN is returned for
+    those.
+    """
+    if n_frags != 1:
+        return np.full(len(FEATURE_NAMES), np.nan, dtype=np.float32)
+
+    atom_ids = _atom_ids(props_regular)
+    atomic_nums = props_regular.atomic_nums
+    # a heteroatom here is anything but carbon and hydrogen, unlike the
+    # carbon-only definition AtomicProperties.is_hetero uses
+    is_hetero = (atomic_nums != _HYDROGEN_ATOMIC_NUM) & (
+        atomic_nums != _CARBON_ATOMIC_NUM
+    )
+    selections = [
+        np.ones(props_regular.num_atoms, dtype=bool),
+        is_hetero,
+        atomic_nums == _CARBON_ATOMIC_NUM,
+        atomic_nums == _NITROGEN_ATOMIC_NUM,
+        atomic_nums == _OXYGEN_ATOMIC_NUM,
+        np.isin(atomic_nums, _HALOGEN_ATOMIC_NUMS),
+    ]
+
+    values = []
+    for selection in selections:
+        molecular_id = atom_ids[selection].sum()
+        # averaged over every atom of the molecule, not over the selected ones
+        values += [molecular_id, molecular_id / props_regular.num_atoms]
+
+    return np.asarray(values, dtype=np.float32)
+
+
+def _atom_ids(props: AtomicProperties) -> np.ndarray:
+    """
+    Atomic ID of every atom: one plus half the sum, over all simple paths
+    starting at that atom, of the inverse square root of the product of the
+    path's edge weights.
+    """
+    adjacency = _weighted_adjacency(props)
+    num_atoms = props.num_atoms
+    visited = bytearray(num_atoms)
+
+    return np.fromiter(
+        (
+            1.0 + _sum_over_paths(adjacency, visited, start, 1) / 2.0
+            for start in range(num_atoms)
+        ),
+        dtype=np.float64,
+        count=num_atoms,
+    )
+
+
+def _weighted_adjacency(props: AtomicProperties) -> list[list[tuple[int, int]]]:
+    """
+    Neighbors of every atom paired with their bond weight, the product of the
+    degrees of the two bonded atoms.
+
+    Kept as nested Python lists of plain ints rather than NumPy arrays: the path
+    search below reads them one edge at a time, where boxing NumPy scalars costs
+    far more than the lookup itself.
+    """
+    degrees = props.degrees
+    begin_idxs = props.bond_begin_idxs.tolist()
+    end_idxs = props.bond_end_idxs.tolist()
+    weights = (degrees[props.bond_begin_idxs] * degrees[props.bond_end_idxs]).tolist()
+
+    adjacency: list[list[tuple[int, int]]] = [[] for _ in range(props.num_atoms)]
+    for begin, end, weight in zip(begin_idxs, end_idxs, weights, strict=True):
+        adjacency[begin].append((end, weight))
+        adjacency[end].append((begin, weight))
+
+    return adjacency
+
+
+def _sum_over_paths(
+    adjacency: list[list[tuple[int, int]]],
+    visited: bytearray,
+    atom: int,
+    weight_product: int,
+) -> float:
+    """
+    Sum of the inverse square root of the edge weight product over every simple
+    path that extends the one ending at ``atom``.
+
+    ``visited`` marks the atoms already on the path and is restored on the way
+    out, so the same buffer serves every starting atom.
+    """
+    visited[atom] = 1
+    total = 0.0
+
+    for neighbor, weight in adjacency[atom]:
+        if visited[neighbor]:
+            continue
+
+        product = weight_product * weight
+        total += 1.0 / sqrt(product)
+        # a longer path would only add terms below the epsilon, so stop here
+        if product < _WEIGHT_PRODUCT_LIMIT:
+            total += _sum_over_paths(adjacency, visited, neighbor, product)
+
+    visited[atom] = 0
+    return total

--- a/skfp/fingerprints/_new_mordred/descriptors/molecular_id.py
+++ b/skfp/fingerprints/_new_mordred/descriptors/molecular_id.py
@@ -34,14 +34,7 @@ FEATURE_NAMES = [
 # Mordred spells the same number as int(1 / eps ** 2)
 _WEIGHT_PRODUCT_LIMIT = 10**20
 
-_HYDROGEN_ATOMIC_NUM = 1
-_CARBON_ATOMIC_NUM = 6
-_NITROGEN_ATOMIC_NUM = 7
-_OXYGEN_ATOMIC_NUM = 8
-
-# one flag per atomic number, indexed by the atomic number itself. Selecting the
-# halogens this way is a plain gather, where np.isin spends more time sorting its
-# few needles than the whole lookup takes.
+# halogen flag per atomic number, for a fast vectorized NumPy lookup
 _NUM_ATOMIC_NUMBERS = 119  # atomic numbers 0 to 118, as RDKit reports them
 _IS_HALOGEN = np.zeros(_NUM_ATOMIC_NUMBERS, dtype=bool)
 _IS_HALOGEN[sorted(HALOGEN_ATOMIC_NUMS)] = True
@@ -65,15 +58,13 @@ def calc(props_regular: AtomicProperties, n_frags: int) -> np.ndarray:
     atomic_nums = props_regular.atomic_nums
     # a heteroatom here is anything but carbon and hydrogen, unlike the
     # carbon-only definition AtomicProperties.is_hetero uses
-    is_hetero = (atomic_nums != _HYDROGEN_ATOMIC_NUM) & (
-        atomic_nums != _CARBON_ATOMIC_NUM
-    )
+    is_hetero = (atomic_nums != 1) & (atomic_nums != 6)
     molecular_ids = [
         atom_ids.sum(),  # every atom, so no selection to build
         atom_ids[is_hetero].sum(),
-        atom_ids[atomic_nums == _CARBON_ATOMIC_NUM].sum(),
-        atom_ids[atomic_nums == _NITROGEN_ATOMIC_NUM].sum(),
-        atom_ids[atomic_nums == _OXYGEN_ATOMIC_NUM].sum(),
+        atom_ids[atomic_nums == 6].sum(),  # carbon
+        atom_ids[atomic_nums == 7].sum(),  # nitrogen
+        atom_ids[atomic_nums == 8].sum(),  # oxygen
         atom_ids[_IS_HALOGEN[atomic_nums]].sum(),
     ]
 
@@ -90,9 +81,6 @@ def _atom_ids(props: AtomicProperties) -> np.ndarray:
     Atomic ID of every atom: one plus half the sum, over all simple paths
     starting at that atom, of the inverse square root of the product of the
     path's edge weights.
-
-    This is by far the most expensive part of the descriptor; see
-    :func:`_sum_over_paths` for why enumerating those paths is exponential.
     """
     adjacency = _weighted_adjacency(props)
     num_atoms = props.num_atoms
@@ -138,20 +126,12 @@ def _sum_over_paths(
 ) -> float:
     """
     Sum of the inverse square root of the edge weight product over every simple
-    path that extends the one ending at ``atom``.
+    path extending the one that ends at ``atom``.
 
-    This is a backtracking search rather than a plain depth-first traversal:
-    ``visited`` marks the atoms on the *current path*, not the atoms already
-    seen, and the mark is undone on the way out. An atom is therefore re-entered
-    once per route that reaches it, and the recursion has one call per simple
-    path instead of one per atom. The cost is exponential in the number of rings
-    -- a plain traversal of pentacene makes 22 calls from a given atom, this one
-    makes 359 -- and there is no way around it: the sum needs one term per path,
-    and the paths have to be simple, so no per-atom bookkeeping can stand in for
-    walking them. It does degenerate to a plain traversal for acyclic molecules,
-    where only one route reaches each atom.
-
-    Restoring the marks also lets one buffer serve every starting atom.
+    Backtracking search: ``visited`` marks the atoms on the current path and is
+    cleared on the way out, so each simple path is walked once. The cost is
+    exponential in the number of rings. Clearing the marks also lets a single
+    buffer serve every starting atom.
     """
     visited[atom] = 1
     total = 0.0

--- a/tests/fingerprints/_new_mordred/molecular_id.py
+++ b/tests/fingerprints/_new_mordred/molecular_id.py
@@ -1,0 +1,99 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+from rdkit.Chem import GetMolFrags, Mol, MolFromSmiles
+
+from skfp.fingerprints._new_mordred.descriptors.molecular_id import FEATURE_NAMES, calc
+from skfp.fingerprints._new_mordred.utils.atomic_properties import AtomicProperties
+from skfp.fingerprints._new_mordred.utils.mol_preprocess import preprocess_mol
+
+"""
+This code has been adapted from the BSD-licensed mordred-community library.
+https://github.com/JacksonBurns/mordred-community
+
+Reference values for MID and AMID come from mordred-community's own reference
+data (mordred/tests/references/MolecularId.yaml) and are stored at
+./references/molecular_id.json as expected[molecule][descriptor]. The
+element-filtered features are not covered there, so their values below were
+computed with mordred-community.
+
+See skfp/fingerprints/data/mordred-community_bsd_license.txt for the license text.
+"""
+
+with open(Path(__file__).parent / "references" / "molecular_id.json") as f:
+    _REFERENCE = json.load(f)
+
+
+def _calc(mol: Mol) -> dict[str, float]:
+    values = calc(AtomicProperties.from_mol(mol), len(GetMolFrags(mol)))
+    return dict(zip(FEATURE_NAMES, values, strict=True))
+
+
+def _calc_from_smiles(smiles: str) -> dict[str, float]:
+    return _calc(preprocess_mol(MolFromSmiles(smiles)))
+
+
+@pytest.mark.parametrize("molecule", list(_REFERENCE))
+def test_molecular_id_reference_values(molecule, mordred_test_mols):
+    values = _calc(mordred_test_mols[molecule])
+
+    expected = _REFERENCE[molecule]
+    assert_allclose(
+        [values[name] for name in expected],
+        list(expected.values()),
+        rtol=1e-5,
+    )
+
+
+@pytest.mark.parametrize(
+    "smiles, feature, expected",
+    [
+        # a lone heavy atom has no paths, so its atomic id stays at 1
+        ("N", "MID", 1.0),
+        ("N", "MID_N", 1.0),
+        ("CCO", "MID_C", 3.310660),
+        ("CCO", "MID_O", 1.603553),
+        ("CCO", "MID_h", 1.603553),
+        ("CCO", "MID_N", 0.0),
+        ("CN1C=NC2=C1C(=O)N(C)C(=O)N2C", "MID_N", 8.359750),
+        ("CN1C=NC2=C1C(=O)N(C)C(=O)N2C", "MID_O", 3.521046),
+        ("CN1C=NC2=C1C(=O)N(C)C(=O)N2C", "MID_h", 11.880796),
+        ("CS(=O)(=O)N", "MID_N", 1.625),
+        ("CS(=O)(=O)N", "MID_O", 3.25),
+        # every halogen is also a heteroatom, and nothing here is carbon but one atom
+        ("FC(F)(Cl)Br", "MID_X", 6.5),
+        ("FC(F)(Cl)Br", "MID_h", 6.5),
+        ("FC(F)(Cl)Br", "MID_C", 2.0),
+        ("Clc1ccccc1", "MID_X", 1.745348),
+        # hydrogens that RemoveHs keeps are not heteroatoms, unlike every other
+        # non-carbon atom
+        ("[H][H]", "MID", 3.0),
+        ("[H][H]", "MID_h", 0.0),
+        ("[2H]C([2H])([2H])O", "MID_h", 1.625),
+    ],
+)
+def test_element_filtered_ids(smiles, feature, expected):
+    values = _calc_from_smiles(smiles)
+
+    assert_allclose(values[feature], expected, rtol=1e-5, atol=1e-6)
+
+
+def test_averaged_ids_divide_by_every_heavy_atom():
+    # AMID_C averages the carbon-only sum over all three heavy atoms, not over
+    # the two carbons
+    values = _calc_from_smiles("CCO")
+
+    assert_allclose(values["AMID_C"], values["MID_C"] / 3, rtol=1e-6)
+    assert_allclose(values["AMID_O"], values["MID_O"] / 3, rtol=1e-6)
+
+
+def test_disconnected_molecule_is_nan():
+    # atomic ids are undefined without a connected graph; mordred reports
+    # "multiple fragments" for these
+    values = _calc_from_smiles("[Na+].[Cl-]")
+
+    assert len(values) == len(FEATURE_NAMES)
+    assert all(np.isnan(value) for value in values.values())

--- a/tests/fingerprints/_new_mordred/references/molecular_id.json
+++ b/tests/fingerprints/_new_mordred/references/molecular_id.json
@@ -1,0 +1,23 @@
+{
+  "Hexane": {"MID": 10.83915043, "AMID": 1.806525072},
+  "Benzene": {"MID": 11.8125, "AMID": 1.96875},
+  "Caffeine": {"MID": 27.80010233, "AMID": 1.985721595},
+  "Cyanidin": {"MID": 42.68983013, "AMID": 2.032849054},
+  "Lycopene": {"MID": 77.41561711, "AMID": 1.935390428},
+  "Epicatechin": {"MID": 42.68983013, "AMID": 2.032849054},
+  "Limonene": {"MID": 19.38570823, "AMID": 1.938570823},
+  "Allicin": {"MID": 16.65502353, "AMID": 1.85055817},
+  "Glutathione": {"MID": 37.80131214, "AMID": 1.890065607},
+  "Digoxin": {"MID": 113.2392334, "AMID": 2.058895153},
+  "Capsaicin": {"MID": 43.08947003, "AMID": 1.958612274},
+  "EllagicAcid": {"MID": 45.46110533, "AMID": 2.066413879},
+  "Astaxanthin": {"MID": 86.16657979, "AMID": 1.958331359},
+  "DMSO": {"MID": 6.732050808, "AMID": 1.683012702},
+  "DiethylThioketone": {"MID": 10.6758508, "AMID": 1.779308466},
+  "VinylsulfonicAcid": {"MID": 10.46599026, "AMID": 1.74433171},
+  "Thiophene": {"MID": 9.6875, "AMID": 1.9375},
+  "Triethoxyphosphine": {"MID": 18.66994061, "AMID": 1.866994061},
+  "MethylphosphonicAcid": {"MID": 8.5, "AMID": 1.7},
+  "MethylCyclopropane": {"MID": 7.175868588, "AMID": 1.793967147},
+  "Acetonitrile": {"MID": 4.914213562, "AMID": 1.638071187}
+}


### PR DESCRIPTION
## Changes

Ports mordred's `MolecularId`: `MID` and `AMID` over all atoms, heteroatoms,
carbons, nitrogens, oxygens and halogens. The feature names were already in
`feature_names.py` and returned NaN until now.

Three commits: the descriptor, a follow-up trimming its fixed per-molecule
cost, and a docstring explaining the algorithmic cost for future readers.

## Why this one is expensive

An atomic ID sums the inverse square root of the edge weight product over every
simple path starting at that atom. The search is a backtracking walk, not a
plain DFS — the visited mark means "on the current path" and is undone on the
way out — so it runs once per simple path rather than once per atom.

The cost is therefore exponential in the number of **rings**, not in molecule
size. For an acyclic molecule there is exactly one path per ordered pair of
atoms, so the walk degenerates to a plain traversal; each independent cycle
multiplies the number of routes:

| molecule | atoms | rings | calls from one atom |
|---|---|---|---|
| octane | 8 | 0 | 8 (same as a plain DFS) |
| benzene | 6 | 1 | 11 |
| naphthalene | 10 | 2 | 32 |
| pentacene | 22 | 5 | 359 |
| cubane cage | 9 | 5 | 151 |

There is no value-preserving shortcut: the sum needs one term per path, and the
paths must be simple, so the state is the whole visited set rather than the
current atom — no per-atom dynamic programming can stand in for walking them.
This makes it the most expensive descriptor in the package.

## Performance

The arithmetic matches mordred exactly. The speedup comes from constants: the
graph is nested lists of plain ints instead of a networkx graph (which cost two
dict lookups per edge), visited atoms live in a `bytearray` instead of a `set`,
and partial sums are returned rather than accumulated on an object.

Best of N runs after warm-up:

| molecule | atoms | mordred | this | |
|---|---|---|---|---|
| Digoxin | 55 | 120.2 ms | 26.6 ms | 4.6× |
| pentacene | 22 | 12.8 ms | 2.5 ms | 5.4× |
| EllagicAcid | 22 | 9.6 ms | 2.0 ms | 5.7× |
| Lycopene | 40 | 3.6 ms | 0.59 ms | 6.2× |
| Caffeine | 14 | 1.6 ms | 0.26 ms | 6.2× |
| Benzene | 6 | 0.41 ms | 0.05 ms | 8.8× |

The second commit targets small molecules, where a size-independent ~35 µs of
mask building dominated everything else. Selecting halogens with `np.isin` alone
took 17.9 µs on a 12-atom molecule — sorting its handful of needles costs more
than the lookup — against 0.33 µs for a boolean table indexed by atomic number.
That, plus dropping the all-true mask for the first feature pair, takes the
fixed part from ~35 µs to ~15 µs: ethane goes from 43.6 µs to 24.3 µs, benzene
from 60.8 µs to 46.6 µs. Larger molecules are unaffected, being dominated by
the path search.

## Correctness

Verified against mordred on 35 molecules (the bundled reference set plus an
aminoglycoside, a fused polycyclic and inositol): worst relative difference
**5.77e-08**, below float32 resolution, and unchanged by the optimisation
commit. Disconnected molecules give NaN on both sides, matching mordred's
`require_connected`.

## Notes for reviewers

A heteroatom here is anything but carbon **and hydrogen**, unlike
`AtomicProperties.is_hetero`, which is carbon-only. This differs only for the
hydrogens `RemoveHs` keeps — `[H][H]` has `MID_h == 0`, where the shared
predicate would give 3.0 — and two tests pin it.

Reference values for `MID`/`AMID` are converted from mordred-community's own
`tests/references/MolecularId.yaml`. The element-filtered features are not
covered there, so those values were computed with mordred-community; the test
module's docstring records both provenances.


## Checklist before requesting a review
- [ ] Docstrings added/updated in public functions and classes
- [ ] Tests added, reasonable test coverage (at least ~90%, `make test-coverage`)
- [ ] Sphinx docs added/updated and render properly (`make docs` and see `docs/_build/index.html`)
